### PR TITLE
Add tslint rule for only ES6 arrow functions (no function syntax)

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -60,6 +60,7 @@
             "check-open-brace",
             "check-whitespace"
         ],
+        "only-arrow-functions": true,
         "quotemark": [true, "single", "jsx-double"],
         "radix": true,
         "semicolon": [true, "always"],


### PR DESCRIPTION
There really should be no need for 'function'. Especially when Traditional functions don’t bind lexical scope (and Typescript does), which can lead to unexpected behavior when accessing ‘this’.

https://palantir.github.io/tslint/rules/only-arrow-functions/