### PR TITLE
SWS-215: Side panel mock-up with fake data

### DIFF
--- a/src/app/__tests__/App.test.tsx
+++ b/src/app/__tests__/App.test.tsx
@@ -27,6 +27,10 @@ process.env.REACT_APP_NAME = 'swsui-test';
 process.env.REACT_APP_VERSION = '1.0.1';
 process.env.REACT_APP_GIT_HASH = '89323';
 
+// TODO: properly handle SVG and D3 in the following 2 components
+jest.mock('../../pages/ServiceDetails/ServiceInfo/ServiceInfoBadge');
+jest.mock('../../pages/ServiceGraph/SummaryPanel');
+
 it('renders full App without crashing', () => {
   const div = document.createElement('div');
   ReactDOM.render(<App />, div);

--- a/src/pages/ServiceGraph/SummaryPanel.tsx
+++ b/src/pages/ServiceGraph/SummaryPanel.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
+import ServiceInfoBadge from '../ServiceDetails/ServiceInfo/ServiceInfoBadge';
+import { AreaChart, PieChart } from 'patternfly-react';
 
-function SummaryPanel() {
-  const panelStyle = {
+export default class SummaryPanel extends React.Component {
+  static readonly panelStyle = {
     position: 'absolute' as 'absolute',
     width: '25em',
     bottom: 0,
@@ -9,16 +11,104 @@ function SummaryPanel() {
     right: 0
   };
 
-  return (
-    <div className="panel panel-default" style={panelStyle}>
-      <div className="panel-heading">
-        <h3 className="panel-title">Service summary</h3>
+  render() {
+    return (
+      <div className="panel panel-default" style={SummaryPanel.panelStyle}>
+        <div className="panel-heading">
+          <h3 className="panel-title">productpage</h3>
+        </div>
+        <div className="panel-body">
+          <p>
+            <strong>Version:</strong> 5<br />
+            <strong>Labels:</strong>
+            <br />
+            {this.renderLabels()}
+          </p>
+          <p>
+            <strong>
+              <a href="#">Go to details page -></a>
+            </strong>
+          </p>
+          <hr />
+          <div style={{ fontSize: '1.2em' }}>
+            {this.renderIncomingRpsChart()}
+            {this.renderOutgoingRpsChart()}
+            {this.renderSuccessRateChart()}
+          </div>
+        </div>
       </div>
-      <div className="panel-body">
-        <em>Summary details</em>
-      </div>
-    </div>
-  );
-}
+    );
+  }
 
-export default SummaryPanel;
+  private renderLabels() {
+    return (
+      <>
+        <ServiceInfoBadge scale={0.8} style="plastic" leftText="app" rightText="bookinfo" color="green" />
+        <ServiceInfoBadge scale={0.8} style="plastic" leftText="app" rightText="product" color="green" />
+        <ServiceInfoBadge scale={0.8} style="plastic" leftText="version" rightText="v5" color="navy" />
+      </>
+    );
+  }
+
+  private renderIncomingRpsChart() {
+    return this.renderRpsChart('Incoming', [350, 400, 150, 850, 50, 220], [140, 100, 50, 700, 10, 110]);
+  }
+
+  private renderOutgoingRpsChart() {
+    return this.renderRpsChart('Outgoing', [350, 400, 150], [140, 100, 130]);
+  }
+
+  private renderRpsChart(label: string, dataRps: number[], dataErrors: number[]) {
+    let lastRps = dataRps.slice(-1)[0];
+    let lastErrors = dataErrors.slice(-1)[0];
+    let lastErrorPercent = Math.round(1000 * lastErrors / lastRps) / 10;
+
+    let rpsColumn: Array<any> = ['RPS'];
+    let errorsColumn: Array<any> = ['Errors'];
+
+    rpsColumn = rpsColumn.concat(dataRps);
+    errorsColumn = errorsColumn.concat(dataErrors);
+
+    return (
+      <>
+        <div>
+          <strong>{label}: </strong>
+          {lastRps} RPS / {lastErrorPercent}% Error
+        </div>
+        <AreaChart
+          size={{ height: 45 }}
+          color={{ pattern: ['#0088ce', '#c00'] }}
+          legend={{ show: false }}
+          grid={{ y: { show: false } }}
+          axis={{ x: { show: false }, y: { show: false } }}
+          data={{
+            columns: [rpsColumn, errorsColumn],
+            type: 'area-spline'
+          }}
+        />
+      </>
+    );
+  }
+
+  private renderSuccessRateChart() {
+    return (
+      <>
+        <div>
+          <PieChart
+            size={{ width: 100, height: 100 }}
+            data={{
+              colors: { '% Success': '#0088ce', '% Fail': '#c00' },
+              columns: [['% Success', 90], ['% Fail', 10]],
+              type: 'pie'
+            }}
+            tooltip={{ contents: () => undefined }}
+            style={{ float: 'left' }}
+          />
+          <br />
+          90% success rate <br />
+          (10% failure)
+        </div>
+      </>
+    );
+  }
+}


### PR DESCRIPTION
It looks like this:
![image](https://user-images.githubusercontent.com/23639005/37184241-f206ebc8-22ff-11e8-821c-c91670dfc9f1.png)

The panel is always there (even if the graph is blank).