### PR TITLE
For service graph - cytoscape graph, use Hexagon instead of circles 

### DIFF
--- a/src/components/CytoscapeLayout/CytoscapeLayout.tsx
+++ b/src/components/CytoscapeLayout/CytoscapeLayout.tsx
@@ -23,7 +23,7 @@ export default class CytoscapeLayout extends React.Component<CytoscapeLayoutProp
   constructor(props: CytoscapeLayoutProps) {
     super(props);
 
-    console.log('Starting ServiceGraphPage for namespace ' + this.props.namespace);
+    console.log('Starting ServiceGraphPage for namespace: ' + this.props.namespace);
 
     this.state = {
       elements: []

--- a/src/components/CytoscapeLayout/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeLayout/graphs/GraphStyles.ts
@@ -8,6 +8,7 @@ export class GraphStyles {
       {
         selector: 'node',
         css: {
+          shape: 'hexagon',
           content: (ele: any) => {
             return ele.data('text') || ele.data('id');
           },
@@ -16,8 +17,9 @@ export class GraphStyles {
           'border-width': '1px',
           'border-color': '#000',
           'font-size': '10px',
-          'text-valign': 'center',
-          'text-halign': 'right'
+          'text-valign': 'bottom',
+          'text-halign': 'right',
+          'text-outline-color': '#77828C'
         }
       },
       {
@@ -51,6 +53,7 @@ export class GraphStyles {
           width: 3,
           color: '#434343',
           'font-size': '8px',
+          'text-margin-x': '25px',
           content: 'data(text)',
           'target-arrow-shape': 'vee',
           'line-color': 'data(color)',


### PR DESCRIPTION
To improve a more sophisticated look, use Hexagon instead of just circles. Also, move node labels down to bottom right for easier readability. And move labels offset to lines so they are move easily seen.

<img width="1211" alt="sws_ui_and_https___react-bootstrap_github_io_components_button-group_" src="https://user-images.githubusercontent.com/1312165/37248710-d8da9b10-248d-11e8-9dab-d22bc7bc40d5.png">

https://issues.jboss.org/browse/SWS-289