### PR TITLE
SWS 299 - Highlight connection and nodes for services

### DIFF
--- a/src/components/CytoscapeLayout/graphs/GraphHighlighter.ts
+++ b/src/components/CytoscapeLayout/graphs/GraphHighlighter.ts
@@ -1,0 +1,126 @@
+const DIM_CLASS: string = 'mousedim';
+
+export class GraphHighlighter {
+  cy: any;
+  service: any;
+  nodeOrEdge: any;
+
+  constructor(cy: any) {
+    this.cy = cy;
+    this.cy.on('tap', this.onTapEvent);
+    this.cy.on('mouseover', 'node,edge', this.onMouseOverNodeOrEdge);
+    this.cy.on('mouseout', 'node,edge', this.onMouseOutNodeOrEdge);
+  }
+
+  // Need to define these methods using the "public class fields syntax", to be able to keep
+  // *this* binded when passing it to events handlers (or use the anoying syntax)
+  // https://reactjs.org/docs/handling-events.html
+  onTapEvent = (event: any) => {
+    const target = event.target;
+    if (target === this.cy) {
+      if (this.service == null) {
+        return;
+      }
+      // Remove the selection when clicking the background
+      this.service
+        .selectify()
+        .unselect()
+        .unselectify();
+      this.service = null;
+      this.refresh();
+    } else if (target.isParent()) {
+      console.log(target.data());
+      // Use it as switch, click once to select, click again to deselect
+      // Remove *selection* when clicking the second time.
+      if (this.service === target) {
+        target
+          .selectify()
+          .unselect()
+          .unselectify();
+      } else {
+        target
+          .selectify()
+          .select()
+          .unselectify();
+      }
+      this.service = this.service === target ? null : target;
+      this.refresh();
+    }
+  };
+
+  onMouseOverNodeOrEdge = (event: any) => {
+    if (event.target.isParent()) {
+      return;
+    }
+    this.nodeOrEdge = event.target;
+    this.refresh();
+  };
+
+  onMouseOutNodeOrEdge = (event: any) => {
+    if (this.nodeOrEdge === event.target) {
+      this.nodeOrEdge = null;
+      this.refresh();
+    }
+  };
+
+  // When you mouse over a service node, that node and the nodes it connects (including the edges)
+  // remain the same, but all other nodes and edges will get dimmed, thus highlighting
+  // the moused over node and its "neighborhood".
+  //
+  // When you mouse over an edge (i.e. a connector betwen nodes), that edge and
+  // the nodes it connects will remain the same, but all others will get dimmed,
+  // thus highlighting the moused over edge and its nodes.
+  //
+  // Note that we never dim the service group box elements (nor do we even process their
+  // mouseout/mousein events). We know an element is a group box if its isParent() returns true.
+  // When a service group box element is selected, we will highlight the nodes it contain,
+  // their related nodes (including edges). Only those nodes will be affected by mouse over
+  // until the service group box is deselected.
+  refresh() {
+    this.cy.elements('.' + DIM_CLASS).removeClass(DIM_CLASS);
+    let toHighlight = this.getServiceCollection();
+    if (toHighlight === null) {
+      toHighlight = this.cy.elements();
+    }
+    const nodeOrEdgeCollection = this.getNodeOrEdgeCollection();
+    if (nodeOrEdgeCollection !== null) {
+      toHighlight = toHighlight.intersect(nodeOrEdgeCollection);
+    }
+
+    this.cy
+      .elements()
+      .difference(toHighlight)
+      .filter(function(ele: any) {
+        return !ele.isParent();
+      })
+      .addClass(DIM_CLASS);
+  }
+
+  // If a service group box is selected, only return their children
+  // and related nodes to children (including edges)
+  // else returns null
+  getServiceCollection() {
+    if (this.service == null) {
+      return null;
+    }
+    return this.service.children().reduce((prev, child) => {
+      if (prev === undefined) {
+        prev = this.cy.collection();
+      }
+      return prev.add(child.closedNeighborhood());
+    });
+  }
+
+  // Returns the collection of related nodes to nodeOrEdge if any has the mouseover
+  // else null;
+  getNodeOrEdgeCollection() {
+    if (this.nodeOrEdge != null) {
+      if (this.nodeOrEdge.isNode()) {
+        return this.nodeOrEdge.closedNeighborhood();
+      } else {
+        return this.nodeOrEdge.connectedNodes().add(this.nodeOrEdge);
+      }
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
 - Highlight related nodes when clicking a service.
 - Mouseover will only highlight related nodes of the service (if one
   is selected).
 - Moved all the highlight code out of the CytoscapeLayout component.

![sws-299-2](https://user-images.githubusercontent.com/3845764/37382836-8d3d1672-270a-11e8-867b-298d4c4cf177.gif)

Issues: When the graph is refreshed, we lose the current selected service.
