### PR TITLE
SWS-277 allow grouping metrics by label

### DIFF
--- a/src/components/MetricsOptions/MetricsOptionsBar.tsx
+++ b/src/components/MetricsOptions/MetricsOptionsBar.tsx
@@ -1,73 +1,147 @@
 import * as React from 'react';
-import { Toolbar, DropdownButton, MenuItem } from 'patternfly-react';
+import { Toolbar, DropdownButton, MenuItem, Filter } from 'patternfly-react';
 import { MetricsOptions } from '../../types/MetricsOptions';
 
 interface Props {
   onOptionsChanged: (opts: MetricsOptions) => void;
 }
 
-interface MetricsOptionsState extends MetricsOptions {}
+interface MetricsOptionsState {
+  rateInterval: string;
+  duration: number;
+  ticks: number;
+  filterLabels: [string, string][];
+  byLabels: string[];
+}
+
+interface ByLabel {
+  labelIn: string;
+  labelOut: string;
+}
 
 export class MetricsOptionsBar extends React.Component<Props, MetricsOptionsState> {
   rateIntervals = [['1m', '1 minute'], ['5m', '5 minutes'], ['10m', '10 minutes'], ['30m', '30 minutes']];
 
-  steps = [
-    ['1', '1 second'],
-    ['5', '5 seconds'],
-    ['15', '15 seconds'],
-    ['30', '30 seconds'],
-    ['60', '1 minute'],
-    ['1800', '30 minutes'],
-    ['3600', '1 hour']
+  ticks = [10, 20, 30, 50, 100, 200];
+
+  durations: [number, string][] = [
+    [300, 'Last 5 minutes'],
+    [600, 'Last 10 minutes'],
+    [1800, 'Last 30 minutes'],
+    [3600, 'Last hour'],
+    [10800, 'Last 3 hours'],
+    [21600, 'Last 6 hours'],
+    [43200, 'Last 12 hours'],
+    [86400, 'Last day']
   ];
 
-  durations = [
-    ['300', 'Last 5 minutes'],
-    ['600', 'Last 10 minutes'],
-    ['1800', 'Last 30 minutes'],
-    ['3600', 'Last hour'],
-    ['10800', 'Last 3 hours'],
-    ['21600', 'Last 6 hours'],
-    ['43200', 'Last 12 hours'],
-    ['86400', 'Last day']
-  ];
+  byLabelOptions: { [key: string]: ByLabel } = {
+    'local version': {
+      labelIn: 'destination_version',
+      labelOut: 'source_version'
+    },
+    'remote service': {
+      labelIn: 'source_service',
+      labelOut: 'destination_service'
+    },
+    'remote version': {
+      labelIn: 'source_version',
+      labelOut: 'destination_version'
+    },
+    'response code': {
+      labelIn: 'response_code',
+      labelOut: 'response_code'
+    }
+  };
+
+  byLabelNames = Object.keys(this.byLabelOptions);
 
   constructor(props: Props) {
     super(props);
 
     this.onRateIntervalChanged = this.onRateIntervalChanged.bind(this);
     this.onDurationChanged = this.onDurationChanged.bind(this);
-    this.onStepChanged = this.onStepChanged.bind(this);
+    this.onTicksChanged = this.onTicksChanged.bind(this);
+    this.addByLabel = this.addByLabel.bind(this);
+    this.removeByLabel = this.removeByLabel.bind(this);
 
     this.state = {
       rateInterval: this.rateIntervals[0][0],
       duration: this.durations[1][0],
-      step: this.steps[2][0],
-      filterLabels: new Map(),
+      ticks: this.ticks[2],
+      filterLabels: [],
       byLabels: []
     };
   }
 
   componentWillMount() {
     // Init state upstream
-    this.props.onOptionsChanged(this.state);
+    this.reportOptions();
   }
 
   onRateIntervalChanged(key: string) {
     this.setState({ rateInterval: key }, () => {
-      this.props.onOptionsChanged(this.state);
+      this.reportOptions();
     });
   }
 
-  onDurationChanged(key: string) {
+  onDurationChanged(key: number) {
     this.setState({ duration: key }, () => {
-      this.props.onOptionsChanged(this.state);
+      this.reportOptions();
     });
   }
 
-  onStepChanged(key: string) {
-    this.setState({ step: key }, () => {
-      this.props.onOptionsChanged(this.state);
+  onTicksChanged(key: number) {
+    this.setState({ ticks: key }, () => {
+      this.reportOptions();
+    });
+  }
+
+  reportOptions() {
+    // State-to-options converter (removes unnecessary properties)
+    const labelsIn = this.state.byLabels.map(lbl => this.byLabelOptions[lbl].labelIn);
+    const labelsOut = this.state.byLabels.map(lbl => this.byLabelOptions[lbl].labelOut);
+    this.props.onOptionsChanged({
+      rateInterval: this.state.rateInterval,
+      duration: this.state.duration,
+      step: this.state.duration / this.state.ticks,
+      filterLabels: this.state.filterLabels,
+      byLabelsIn: labelsIn,
+      byLabelsOut: labelsOut
+    });
+  }
+
+  addByLabel(key: string) {
+    if (!this.byLabelOptions.hasOwnProperty(key)) {
+      // Probably placeholder click
+      return;
+    }
+    const labels = this.state.byLabels.slice();
+    const idx = labels.indexOf(key);
+    if (idx < 0) {
+      // Added
+      labels.push(key);
+    }
+    this.setState({ byLabels: labels }, () => {
+      this.reportOptions();
+    });
+  }
+
+  removeByLabel(key: string) {
+    const labels = this.state.byLabels.slice();
+    const idx = labels.indexOf(key);
+    if (idx >= 0) {
+      // Removed
+      labels.splice(idx, 1);
+    }
+    this.setState({ byLabels: labels }, () => {
+      this.reportOptions();
+    });
+  }
+
+  clearFilters() {
+    this.setState({ byLabels: [] }, () => {
+      this.reportOptions();
     });
   }
 
@@ -82,10 +156,10 @@ export class MetricsOptionsBar extends React.Component<Props, MetricsOptionsStat
               </MenuItem>
             ))}
           </DropdownButton>
-          <DropdownButton id="step" title="Step" onSelect={this.onStepChanged}>
-            {this.steps.map(r => (
-              <MenuItem key={r[0]} active={r[0] === this.state.step} eventKey={r[0]}>
-                {r[1]}
+          <DropdownButton id="ticks" title="Ticks" onSelect={this.onTicksChanged}>
+            {this.ticks.map(r => (
+              <MenuItem key={r} active={r === this.state.ticks} eventKey={r}>
+                {r}
               </MenuItem>
             ))}
           </DropdownButton>
@@ -96,6 +170,38 @@ export class MetricsOptionsBar extends React.Component<Props, MetricsOptionsStat
               </MenuItem>
             ))}
           </DropdownButton>
+        </div>
+        <div className="form-group">
+          <Filter>
+            <Filter.ValueSelector
+              filterValues={this.byLabelNames}
+              placeholder="Group by"
+              onFilterValueSelected={this.addByLabel}
+            />
+          </Filter>
+          {this.state.byLabels.length > 0 && (
+            <Toolbar.Results>
+              <Filter.ActiveLabel>{'Grouping by:'}</Filter.ActiveLabel>
+              <Filter.List>
+                {this.state.byLabels.map(label => {
+                  return (
+                    <Filter.Item key={label} onRemove={this.removeByLabel} filterData={label}>
+                      {label}
+                    </Filter.Item>
+                  );
+                })}
+              </Filter.List>
+              <a
+                href="#"
+                onClick={e => {
+                  e.preventDefault();
+                  this.clearFilters();
+                }}
+              >
+                Clear all
+              </a>
+            </Toolbar.Results>
+          )}
         </div>
       </Toolbar>
     );

--- a/src/components/MetricsOptions/MetricsOptionsBar.tsx
+++ b/src/components/MetricsOptions/MetricsOptionsBar.tsx
@@ -20,11 +20,13 @@ interface ByLabel {
 }
 
 export class MetricsOptionsBar extends React.Component<Props, MetricsOptionsState> {
-  rateIntervals = [['1m', '1 minute'], ['5m', '5 minutes'], ['10m', '10 minutes'], ['30m', '30 minutes']];
+  static RateIntervals = [['1m', '1 minute'], ['5m', '5 minutes'], ['10m', '10 minutes'], ['30m', '30 minutes']];
+  static DefaultRateInterval = MetricsOptionsBar.RateIntervals[0][0];
 
-  ticks = [10, 20, 30, 50, 100, 200];
+  static Ticks = [10, 20, 30, 50, 100, 200];
+  static DefaultTicks = MetricsOptionsBar.Ticks[2];
 
-  durations: [number, string][] = [
+  static Durations: [number, string][] = [
     [300, 'Last 5 minutes'],
     [600, 'Last 10 minutes'],
     [1800, 'Last 30 minutes'],
@@ -34,8 +36,9 @@ export class MetricsOptionsBar extends React.Component<Props, MetricsOptionsStat
     [43200, 'Last 12 hours'],
     [86400, 'Last day']
   ];
+  static DefaultDuration = MetricsOptionsBar.Durations[1][0];
 
-  byLabelOptions: { [key: string]: ByLabel } = {
+  static ByLabelOptions: { [key: string]: ByLabel } = {
     'local version': {
       labelIn: 'destination_version',
       labelOut: 'source_version'
@@ -54,7 +57,7 @@ export class MetricsOptionsBar extends React.Component<Props, MetricsOptionsStat
     }
   };
 
-  byLabelNames = Object.keys(this.byLabelOptions);
+  static ByLabelNames = Object.keys(MetricsOptionsBar.ByLabelOptions);
 
   constructor(props: Props) {
     super(props);
@@ -66,9 +69,9 @@ export class MetricsOptionsBar extends React.Component<Props, MetricsOptionsStat
     this.removeByLabel = this.removeByLabel.bind(this);
 
     this.state = {
-      rateInterval: this.rateIntervals[0][0],
-      duration: this.durations[1][0],
-      ticks: this.ticks[2],
+      rateInterval: MetricsOptionsBar.DefaultRateInterval,
+      duration: MetricsOptionsBar.DefaultDuration,
+      ticks: MetricsOptionsBar.DefaultTicks,
       filterLabels: [],
       byLabels: []
     };
@@ -99,8 +102,8 @@ export class MetricsOptionsBar extends React.Component<Props, MetricsOptionsStat
 
   reportOptions() {
     // State-to-options converter (removes unnecessary properties)
-    const labelsIn = this.state.byLabels.map(lbl => this.byLabelOptions[lbl].labelIn);
-    const labelsOut = this.state.byLabels.map(lbl => this.byLabelOptions[lbl].labelOut);
+    const labelsIn = this.state.byLabels.map(lbl => MetricsOptionsBar.ByLabelOptions[lbl].labelIn);
+    const labelsOut = this.state.byLabels.map(lbl => MetricsOptionsBar.ByLabelOptions[lbl].labelOut);
     this.props.onOptionsChanged({
       rateInterval: this.state.rateInterval,
       duration: this.state.duration,
@@ -112,7 +115,7 @@ export class MetricsOptionsBar extends React.Component<Props, MetricsOptionsStat
   }
 
   addByLabel(key: string) {
-    if (!this.byLabelOptions.hasOwnProperty(key)) {
+    if (!MetricsOptionsBar.ByLabelOptions.hasOwnProperty(key)) {
       // Probably placeholder click
       return;
     }
@@ -150,21 +153,21 @@ export class MetricsOptionsBar extends React.Component<Props, MetricsOptionsStat
       <Toolbar>
         <div className="form-group">
           <DropdownButton id="duration" title="Duration" onSelect={this.onDurationChanged}>
-            {this.durations.map(r => (
+            {MetricsOptionsBar.Durations.map(r => (
               <MenuItem key={r[0]} active={r[0] === this.state.duration} eventKey={r[0]}>
                 {r[1]}
               </MenuItem>
             ))}
           </DropdownButton>
           <DropdownButton id="ticks" title="Ticks" onSelect={this.onTicksChanged}>
-            {this.ticks.map(r => (
+            {MetricsOptionsBar.Ticks.map(r => (
               <MenuItem key={r} active={r === this.state.ticks} eventKey={r}>
                 {r}
               </MenuItem>
             ))}
           </DropdownButton>
           <DropdownButton id="rateInterval" title="Rate interval" onSelect={this.onRateIntervalChanged}>
-            {this.rateIntervals.map(r => (
+            {MetricsOptionsBar.RateIntervals.map(r => (
               <MenuItem key={r[0]} active={r[0] === this.state.rateInterval} eventKey={r[0]}>
                 {r[1]}
               </MenuItem>
@@ -174,7 +177,7 @@ export class MetricsOptionsBar extends React.Component<Props, MetricsOptionsStat
         <div className="form-group">
           <Filter>
             <Filter.ValueSelector
-              filterValues={this.byLabelNames}
+              filterValues={MetricsOptionsBar.ByLabelNames}
               placeholder="Group by"
               onFilterValueSelected={this.addByLabel}
             />

--- a/src/components/MetricsOptions/ValueSelectHelper.tsx
+++ b/src/components/MetricsOptions/ValueSelectHelper.tsx
@@ -1,0 +1,106 @@
+import * as React from 'react';
+import { Filter } from 'patternfly-react';
+
+interface Props {
+  dropdownTitle: string;
+  resultsTitle: string;
+  items: string[];
+  onChange: (selected: string[]) => void;
+}
+
+interface Item {
+  name: string;
+  selected: boolean;
+}
+
+export class ValueSelectHelper {
+  items: Item[];
+  available: string[];
+  selected: string[];
+  props: Props;
+
+  constructor(props: Props) {
+    this.props = props;
+    this.add = this.add.bind(this);
+    this.remove = this.remove.bind(this);
+    this.clear = this.clear.bind(this);
+
+    this.items = props.items.map(name => ({ name: name, selected: false }));
+    this.computeState();
+  }
+
+  computeState() {
+    this.available = this.items.filter(it => !it.selected).map(it => it.name);
+    this.selected = this.items.filter(it => it.selected).map(it => it.name);
+  }
+
+  add(key: string) {
+    const item = this.items.find(it => it.name === key);
+    // If item is not found, probably was placeholder click
+    if (item) {
+      item.selected = true;
+      this.computeState();
+      this.props.onChange(this.selected);
+    }
+  }
+
+  remove(key: string) {
+    const item = this.items.find(it => it.name === key);
+    // If item is not found, probably was placeholder click
+    if (item) {
+      item.selected = false;
+      this.computeState();
+      this.props.onChange(this.selected);
+    }
+  }
+
+  clear() {
+    this.items.forEach(it => (it.selected = false));
+    this.computeState();
+    this.props.onChange(this.selected);
+  }
+
+  renderDropdown() {
+    return (
+      <Filter>
+        <Filter.ValueSelector
+          filterValues={this.available}
+          placeholder={this.props.dropdownTitle}
+          onFilterValueSelected={this.add}
+        />
+      </Filter>
+    );
+  }
+
+  hasResults(): boolean {
+    return this.selected.length > 0;
+  }
+
+  renderResults() {
+    return (
+      <>
+        <Filter.ActiveLabel>{this.props.resultsTitle}</Filter.ActiveLabel>
+        <Filter.List>
+          {this.selected.map(item => {
+            return (
+              <Filter.Item key={item} onRemove={this.remove} filterData={item}>
+                {item}
+              </Filter.Item>
+            );
+          })}
+        </Filter.List>
+        <a
+          href="#"
+          onClick={e => {
+            e.preventDefault();
+            this.clear();
+          }}
+        >
+          Clear all
+        </a>
+      </>
+    );
+  }
+}
+
+export default ValueSelectHelper;

--- a/src/components/MetricsOptions/__tests__/MetricsOptionsBar.test.tsx
+++ b/src/components/MetricsOptions/__tests__/MetricsOptionsBar.test.tsx
@@ -11,21 +11,17 @@ const lastOptionsChanged = () => {
 describe('MetricsOptionsBar', () => {
   it('renders initial layout', () => {
     const wrapper = shallow(<MetricsOptionsBar onOptionsChanged={jest.fn()} />);
-    const eltDuration = wrapper.find('#duration');
-    expect(eltDuration.length).toBe(1);
-    const eltStep = wrapper.find('#step');
-    expect(eltStep.length).toBe(1);
-    const eltRateInterval = wrapper.find('#rateInterval');
-    expect(eltRateInterval.length).toBe(1);
+    expect(wrapper).toMatchSnapshot();
   });
 
   it('changes trigger parent callback', () => {
     const wrapper = mount(<MetricsOptionsBar onOptionsChanged={optionsChanged} />);
     expect(optionsChanged).toHaveBeenCalledTimes(1);
     const opts = lastOptionsChanged();
-    expect(opts).toHaveProperty('duration', '600');
-    expect(opts).toHaveProperty('step', '15');
-    expect(opts).toHaveProperty('rateInterval', '1m');
+    // Step = duration / ticks
+    expect(opts).toHaveProperty('duration', MetricsOptionsBar.DefaultDuration);
+    expect(opts).toHaveProperty('step', MetricsOptionsBar.DefaultDuration / MetricsOptionsBar.DefaultTicks);
+    expect(opts).toHaveProperty('rateInterval', MetricsOptionsBar.DefaultRateInterval);
 
     let elt = wrapper
       .find('#duration')
@@ -33,15 +29,17 @@ describe('MetricsOptionsBar', () => {
       .first();
     elt.simulate('click');
     expect(optionsChanged).toHaveBeenCalledTimes(2);
-    expect(lastOptionsChanged()).toHaveProperty('duration', '300');
+    const expectedDuration = MetricsOptionsBar.Durations[0][0];
+    expect(lastOptionsChanged()).toHaveProperty('duration', expectedDuration);
+    expect(lastOptionsChanged()).toHaveProperty('step', expectedDuration / MetricsOptionsBar.DefaultTicks);
 
     elt = wrapper
-      .find('#step')
+      .find('#ticks')
       .find('SafeAnchor')
       .first();
     elt.simulate('click');
     expect(optionsChanged).toHaveBeenCalledTimes(3);
-    expect(lastOptionsChanged()).toHaveProperty('step', '1');
+    expect(lastOptionsChanged()).toHaveProperty('step', expectedDuration / MetricsOptionsBar.Ticks[0]);
 
     elt = wrapper
       .find('#rateInterval')
@@ -49,6 +47,9 @@ describe('MetricsOptionsBar', () => {
       .last();
     elt.simulate('click');
     expect(optionsChanged).toHaveBeenCalledTimes(4);
-    expect(lastOptionsChanged()).toHaveProperty('rateInterval', '30m');
+    expect(lastOptionsChanged()).toHaveProperty(
+      'rateInterval',
+      MetricsOptionsBar.RateIntervals[MetricsOptionsBar.RateIntervals.length - 1][0]
+    );
   });
 });

--- a/src/components/MetricsOptions/__tests__/__snapshots__/MetricsOptionsBar.test.tsx.snap
+++ b/src/components/MetricsOptions/__tests__/__snapshots__/MetricsOptionsBar.test.tsx.snap
@@ -1,0 +1,2123 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MetricsOptionsBar renders initial layout 1`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <MetricsOptionsBar
+    onOptionsChanged={[Function]}
+/>,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "class",
+    "props": Object {
+      "children": Array [
+        <div
+          className="form-group"
+>
+          <DropdownButton
+                    id="duration"
+                    onSelect={[Function]}
+                    title="Duration"
+          >
+                    <MenuItem
+                              active={false}
+                              bsClass="dropdown"
+                              disabled={false}
+                              divider={false}
+                              eventKey={300}
+                              header={false}
+                    >
+                              Last 5 minutes
+                    </MenuItem>
+                    <MenuItem
+                              active={true}
+                              bsClass="dropdown"
+                              disabled={false}
+                              divider={false}
+                              eventKey={600}
+                              header={false}
+                    >
+                              Last 10 minutes
+                    </MenuItem>
+                    <MenuItem
+                              active={false}
+                              bsClass="dropdown"
+                              disabled={false}
+                              divider={false}
+                              eventKey={1800}
+                              header={false}
+                    >
+                              Last 30 minutes
+                    </MenuItem>
+                    <MenuItem
+                              active={false}
+                              bsClass="dropdown"
+                              disabled={false}
+                              divider={false}
+                              eventKey={3600}
+                              header={false}
+                    >
+                              Last hour
+                    </MenuItem>
+                    <MenuItem
+                              active={false}
+                              bsClass="dropdown"
+                              disabled={false}
+                              divider={false}
+                              eventKey={10800}
+                              header={false}
+                    >
+                              Last 3 hours
+                    </MenuItem>
+                    <MenuItem
+                              active={false}
+                              bsClass="dropdown"
+                              disabled={false}
+                              divider={false}
+                              eventKey={21600}
+                              header={false}
+                    >
+                              Last 6 hours
+                    </MenuItem>
+                    <MenuItem
+                              active={false}
+                              bsClass="dropdown"
+                              disabled={false}
+                              divider={false}
+                              eventKey={43200}
+                              header={false}
+                    >
+                              Last 12 hours
+                    </MenuItem>
+                    <MenuItem
+                              active={false}
+                              bsClass="dropdown"
+                              disabled={false}
+                              divider={false}
+                              eventKey={86400}
+                              header={false}
+                    >
+                              Last day
+                    </MenuItem>
+          </DropdownButton>
+          <DropdownButton
+                    id="ticks"
+                    onSelect={[Function]}
+                    title="Ticks"
+          >
+                    <MenuItem
+                              active={false}
+                              bsClass="dropdown"
+                              disabled={false}
+                              divider={false}
+                              eventKey={10}
+                              header={false}
+                    >
+                              10
+                    </MenuItem>
+                    <MenuItem
+                              active={false}
+                              bsClass="dropdown"
+                              disabled={false}
+                              divider={false}
+                              eventKey={20}
+                              header={false}
+                    >
+                              20
+                    </MenuItem>
+                    <MenuItem
+                              active={true}
+                              bsClass="dropdown"
+                              disabled={false}
+                              divider={false}
+                              eventKey={30}
+                              header={false}
+                    >
+                              30
+                    </MenuItem>
+                    <MenuItem
+                              active={false}
+                              bsClass="dropdown"
+                              disabled={false}
+                              divider={false}
+                              eventKey={50}
+                              header={false}
+                    >
+                              50
+                    </MenuItem>
+                    <MenuItem
+                              active={false}
+                              bsClass="dropdown"
+                              disabled={false}
+                              divider={false}
+                              eventKey={100}
+                              header={false}
+                    >
+                              100
+                    </MenuItem>
+                    <MenuItem
+                              active={false}
+                              bsClass="dropdown"
+                              disabled={false}
+                              divider={false}
+                              eventKey={200}
+                              header={false}
+                    >
+                              200
+                    </MenuItem>
+          </DropdownButton>
+          <DropdownButton
+                    id="rateInterval"
+                    onSelect={[Function]}
+                    title="Rate interval"
+          >
+                    <MenuItem
+                              active={true}
+                              bsClass="dropdown"
+                              disabled={false}
+                              divider={false}
+                              eventKey="1m"
+                              header={false}
+                    >
+                              1 minute
+                    </MenuItem>
+                    <MenuItem
+                              active={false}
+                              bsClass="dropdown"
+                              disabled={false}
+                              divider={false}
+                              eventKey="5m"
+                              header={false}
+                    >
+                              5 minutes
+                    </MenuItem>
+                    <MenuItem
+                              active={false}
+                              bsClass="dropdown"
+                              disabled={false}
+                              divider={false}
+                              eventKey="10m"
+                              header={false}
+                    >
+                              10 minutes
+                    </MenuItem>
+                    <MenuItem
+                              active={false}
+                              bsClass="dropdown"
+                              disabled={false}
+                              divider={false}
+                              eventKey="30m"
+                              header={false}
+                    >
+                              30 minutes
+                    </MenuItem>
+          </DropdownButton>
+</div>,
+        <div
+          className="form-group"
+>
+          <getContext(Filter)>
+                    <FilterValueSelector
+                              filterValues={
+                                        Array [
+                                                  "local version",
+                                                  "remote service",
+                                                  "remote version",
+                                                  "response code",
+                                                ]
+                              }
+                              onFilterValueSelected={[Function]}
+                              placeholder="Group by"
+                    />
+          </getContext(Filter)>
+</div>,
+      ],
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": Array [
+            <DropdownButton
+              id="duration"
+              onSelect={[Function]}
+              title="Duration"
+>
+              <MenuItem
+                            active={false}
+                            bsClass="dropdown"
+                            disabled={false}
+                            divider={false}
+                            eventKey={300}
+                            header={false}
+              >
+                            Last 5 minutes
+              </MenuItem>
+              <MenuItem
+                            active={true}
+                            bsClass="dropdown"
+                            disabled={false}
+                            divider={false}
+                            eventKey={600}
+                            header={false}
+              >
+                            Last 10 minutes
+              </MenuItem>
+              <MenuItem
+                            active={false}
+                            bsClass="dropdown"
+                            disabled={false}
+                            divider={false}
+                            eventKey={1800}
+                            header={false}
+              >
+                            Last 30 minutes
+              </MenuItem>
+              <MenuItem
+                            active={false}
+                            bsClass="dropdown"
+                            disabled={false}
+                            divider={false}
+                            eventKey={3600}
+                            header={false}
+              >
+                            Last hour
+              </MenuItem>
+              <MenuItem
+                            active={false}
+                            bsClass="dropdown"
+                            disabled={false}
+                            divider={false}
+                            eventKey={10800}
+                            header={false}
+              >
+                            Last 3 hours
+              </MenuItem>
+              <MenuItem
+                            active={false}
+                            bsClass="dropdown"
+                            disabled={false}
+                            divider={false}
+                            eventKey={21600}
+                            header={false}
+              >
+                            Last 6 hours
+              </MenuItem>
+              <MenuItem
+                            active={false}
+                            bsClass="dropdown"
+                            disabled={false}
+                            divider={false}
+                            eventKey={43200}
+                            header={false}
+              >
+                            Last 12 hours
+              </MenuItem>
+              <MenuItem
+                            active={false}
+                            bsClass="dropdown"
+                            disabled={false}
+                            divider={false}
+                            eventKey={86400}
+                            header={false}
+              >
+                            Last day
+              </MenuItem>
+</DropdownButton>,
+            <DropdownButton
+              id="ticks"
+              onSelect={[Function]}
+              title="Ticks"
+>
+              <MenuItem
+                            active={false}
+                            bsClass="dropdown"
+                            disabled={false}
+                            divider={false}
+                            eventKey={10}
+                            header={false}
+              >
+                            10
+              </MenuItem>
+              <MenuItem
+                            active={false}
+                            bsClass="dropdown"
+                            disabled={false}
+                            divider={false}
+                            eventKey={20}
+                            header={false}
+              >
+                            20
+              </MenuItem>
+              <MenuItem
+                            active={true}
+                            bsClass="dropdown"
+                            disabled={false}
+                            divider={false}
+                            eventKey={30}
+                            header={false}
+              >
+                            30
+              </MenuItem>
+              <MenuItem
+                            active={false}
+                            bsClass="dropdown"
+                            disabled={false}
+                            divider={false}
+                            eventKey={50}
+                            header={false}
+              >
+                            50
+              </MenuItem>
+              <MenuItem
+                            active={false}
+                            bsClass="dropdown"
+                            disabled={false}
+                            divider={false}
+                            eventKey={100}
+                            header={false}
+              >
+                            100
+              </MenuItem>
+              <MenuItem
+                            active={false}
+                            bsClass="dropdown"
+                            disabled={false}
+                            divider={false}
+                            eventKey={200}
+                            header={false}
+              >
+                            200
+              </MenuItem>
+</DropdownButton>,
+            <DropdownButton
+              id="rateInterval"
+              onSelect={[Function]}
+              title="Rate interval"
+>
+              <MenuItem
+                            active={true}
+                            bsClass="dropdown"
+                            disabled={false}
+                            divider={false}
+                            eventKey="1m"
+                            header={false}
+              >
+                            1 minute
+              </MenuItem>
+              <MenuItem
+                            active={false}
+                            bsClass="dropdown"
+                            disabled={false}
+                            divider={false}
+                            eventKey="5m"
+                            header={false}
+              >
+                            5 minutes
+              </MenuItem>
+              <MenuItem
+                            active={false}
+                            bsClass="dropdown"
+                            disabled={false}
+                            divider={false}
+                            eventKey="10m"
+                            header={false}
+              >
+                            10 minutes
+              </MenuItem>
+              <MenuItem
+                            active={false}
+                            bsClass="dropdown"
+                            disabled={false}
+                            divider={false}
+                            eventKey="30m"
+                            header={false}
+              >
+                            30 minutes
+              </MenuItem>
+</DropdownButton>,
+          ],
+          "className": "form-group",
+        },
+        "ref": null,
+        "rendered": Array [
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "function",
+            "props": Object {
+              "children": Array [
+                <MenuItem
+                  active={false}
+                  bsClass="dropdown"
+                  disabled={false}
+                  divider={false}
+                  eventKey={300}
+                  header={false}
+>
+                  Last 5 minutes
+</MenuItem>,
+                <MenuItem
+                  active={true}
+                  bsClass="dropdown"
+                  disabled={false}
+                  divider={false}
+                  eventKey={600}
+                  header={false}
+>
+                  Last 10 minutes
+</MenuItem>,
+                <MenuItem
+                  active={false}
+                  bsClass="dropdown"
+                  disabled={false}
+                  divider={false}
+                  eventKey={1800}
+                  header={false}
+>
+                  Last 30 minutes
+</MenuItem>,
+                <MenuItem
+                  active={false}
+                  bsClass="dropdown"
+                  disabled={false}
+                  divider={false}
+                  eventKey={3600}
+                  header={false}
+>
+                  Last hour
+</MenuItem>,
+                <MenuItem
+                  active={false}
+                  bsClass="dropdown"
+                  disabled={false}
+                  divider={false}
+                  eventKey={10800}
+                  header={false}
+>
+                  Last 3 hours
+</MenuItem>,
+                <MenuItem
+                  active={false}
+                  bsClass="dropdown"
+                  disabled={false}
+                  divider={false}
+                  eventKey={21600}
+                  header={false}
+>
+                  Last 6 hours
+</MenuItem>,
+                <MenuItem
+                  active={false}
+                  bsClass="dropdown"
+                  disabled={false}
+                  divider={false}
+                  eventKey={43200}
+                  header={false}
+>
+                  Last 12 hours
+</MenuItem>,
+                <MenuItem
+                  active={false}
+                  bsClass="dropdown"
+                  disabled={false}
+                  divider={false}
+                  eventKey={86400}
+                  header={false}
+>
+                  Last day
+</MenuItem>,
+              ],
+              "id": "duration",
+              "onSelect": [Function],
+              "title": "Duration",
+            },
+            "ref": null,
+            "rendered": Array [
+              Object {
+                "instance": null,
+                "key": "300",
+                "nodeType": "class",
+                "props": Object {
+                  "active": false,
+                  "bsClass": "dropdown",
+                  "children": "Last 5 minutes",
+                  "disabled": false,
+                  "divider": false,
+                  "eventKey": 300,
+                  "header": false,
+                },
+                "ref": null,
+                "rendered": "Last 5 minutes",
+                "type": [Function],
+              },
+              Object {
+                "instance": null,
+                "key": "600",
+                "nodeType": "class",
+                "props": Object {
+                  "active": true,
+                  "bsClass": "dropdown",
+                  "children": "Last 10 minutes",
+                  "disabled": false,
+                  "divider": false,
+                  "eventKey": 600,
+                  "header": false,
+                },
+                "ref": null,
+                "rendered": "Last 10 minutes",
+                "type": [Function],
+              },
+              Object {
+                "instance": null,
+                "key": "1800",
+                "nodeType": "class",
+                "props": Object {
+                  "active": false,
+                  "bsClass": "dropdown",
+                  "children": "Last 30 minutes",
+                  "disabled": false,
+                  "divider": false,
+                  "eventKey": 1800,
+                  "header": false,
+                },
+                "ref": null,
+                "rendered": "Last 30 minutes",
+                "type": [Function],
+              },
+              Object {
+                "instance": null,
+                "key": "3600",
+                "nodeType": "class",
+                "props": Object {
+                  "active": false,
+                  "bsClass": "dropdown",
+                  "children": "Last hour",
+                  "disabled": false,
+                  "divider": false,
+                  "eventKey": 3600,
+                  "header": false,
+                },
+                "ref": null,
+                "rendered": "Last hour",
+                "type": [Function],
+              },
+              Object {
+                "instance": null,
+                "key": "10800",
+                "nodeType": "class",
+                "props": Object {
+                  "active": false,
+                  "bsClass": "dropdown",
+                  "children": "Last 3 hours",
+                  "disabled": false,
+                  "divider": false,
+                  "eventKey": 10800,
+                  "header": false,
+                },
+                "ref": null,
+                "rendered": "Last 3 hours",
+                "type": [Function],
+              },
+              Object {
+                "instance": null,
+                "key": "21600",
+                "nodeType": "class",
+                "props": Object {
+                  "active": false,
+                  "bsClass": "dropdown",
+                  "children": "Last 6 hours",
+                  "disabled": false,
+                  "divider": false,
+                  "eventKey": 21600,
+                  "header": false,
+                },
+                "ref": null,
+                "rendered": "Last 6 hours",
+                "type": [Function],
+              },
+              Object {
+                "instance": null,
+                "key": "43200",
+                "nodeType": "class",
+                "props": Object {
+                  "active": false,
+                  "bsClass": "dropdown",
+                  "children": "Last 12 hours",
+                  "disabled": false,
+                  "divider": false,
+                  "eventKey": 43200,
+                  "header": false,
+                },
+                "ref": null,
+                "rendered": "Last 12 hours",
+                "type": [Function],
+              },
+              Object {
+                "instance": null,
+                "key": "86400",
+                "nodeType": "class",
+                "props": Object {
+                  "active": false,
+                  "bsClass": "dropdown",
+                  "children": "Last day",
+                  "disabled": false,
+                  "divider": false,
+                  "eventKey": 86400,
+                  "header": false,
+                },
+                "ref": null,
+                "rendered": "Last day",
+                "type": [Function],
+              },
+            ],
+            "type": [Function],
+          },
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "function",
+            "props": Object {
+              "children": Array [
+                <MenuItem
+                  active={false}
+                  bsClass="dropdown"
+                  disabled={false}
+                  divider={false}
+                  eventKey={10}
+                  header={false}
+>
+                  10
+</MenuItem>,
+                <MenuItem
+                  active={false}
+                  bsClass="dropdown"
+                  disabled={false}
+                  divider={false}
+                  eventKey={20}
+                  header={false}
+>
+                  20
+</MenuItem>,
+                <MenuItem
+                  active={true}
+                  bsClass="dropdown"
+                  disabled={false}
+                  divider={false}
+                  eventKey={30}
+                  header={false}
+>
+                  30
+</MenuItem>,
+                <MenuItem
+                  active={false}
+                  bsClass="dropdown"
+                  disabled={false}
+                  divider={false}
+                  eventKey={50}
+                  header={false}
+>
+                  50
+</MenuItem>,
+                <MenuItem
+                  active={false}
+                  bsClass="dropdown"
+                  disabled={false}
+                  divider={false}
+                  eventKey={100}
+                  header={false}
+>
+                  100
+</MenuItem>,
+                <MenuItem
+                  active={false}
+                  bsClass="dropdown"
+                  disabled={false}
+                  divider={false}
+                  eventKey={200}
+                  header={false}
+>
+                  200
+</MenuItem>,
+              ],
+              "id": "ticks",
+              "onSelect": [Function],
+              "title": "Ticks",
+            },
+            "ref": null,
+            "rendered": Array [
+              Object {
+                "instance": null,
+                "key": "10",
+                "nodeType": "class",
+                "props": Object {
+                  "active": false,
+                  "bsClass": "dropdown",
+                  "children": 10,
+                  "disabled": false,
+                  "divider": false,
+                  "eventKey": 10,
+                  "header": false,
+                },
+                "ref": null,
+                "rendered": 10,
+                "type": [Function],
+              },
+              Object {
+                "instance": null,
+                "key": "20",
+                "nodeType": "class",
+                "props": Object {
+                  "active": false,
+                  "bsClass": "dropdown",
+                  "children": 20,
+                  "disabled": false,
+                  "divider": false,
+                  "eventKey": 20,
+                  "header": false,
+                },
+                "ref": null,
+                "rendered": 20,
+                "type": [Function],
+              },
+              Object {
+                "instance": null,
+                "key": "30",
+                "nodeType": "class",
+                "props": Object {
+                  "active": true,
+                  "bsClass": "dropdown",
+                  "children": 30,
+                  "disabled": false,
+                  "divider": false,
+                  "eventKey": 30,
+                  "header": false,
+                },
+                "ref": null,
+                "rendered": 30,
+                "type": [Function],
+              },
+              Object {
+                "instance": null,
+                "key": "50",
+                "nodeType": "class",
+                "props": Object {
+                  "active": false,
+                  "bsClass": "dropdown",
+                  "children": 50,
+                  "disabled": false,
+                  "divider": false,
+                  "eventKey": 50,
+                  "header": false,
+                },
+                "ref": null,
+                "rendered": 50,
+                "type": [Function],
+              },
+              Object {
+                "instance": null,
+                "key": "100",
+                "nodeType": "class",
+                "props": Object {
+                  "active": false,
+                  "bsClass": "dropdown",
+                  "children": 100,
+                  "disabled": false,
+                  "divider": false,
+                  "eventKey": 100,
+                  "header": false,
+                },
+                "ref": null,
+                "rendered": 100,
+                "type": [Function],
+              },
+              Object {
+                "instance": null,
+                "key": "200",
+                "nodeType": "class",
+                "props": Object {
+                  "active": false,
+                  "bsClass": "dropdown",
+                  "children": 200,
+                  "disabled": false,
+                  "divider": false,
+                  "eventKey": 200,
+                  "header": false,
+                },
+                "ref": null,
+                "rendered": 200,
+                "type": [Function],
+              },
+            ],
+            "type": [Function],
+          },
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "function",
+            "props": Object {
+              "children": Array [
+                <MenuItem
+                  active={true}
+                  bsClass="dropdown"
+                  disabled={false}
+                  divider={false}
+                  eventKey="1m"
+                  header={false}
+>
+                  1 minute
+</MenuItem>,
+                <MenuItem
+                  active={false}
+                  bsClass="dropdown"
+                  disabled={false}
+                  divider={false}
+                  eventKey="5m"
+                  header={false}
+>
+                  5 minutes
+</MenuItem>,
+                <MenuItem
+                  active={false}
+                  bsClass="dropdown"
+                  disabled={false}
+                  divider={false}
+                  eventKey="10m"
+                  header={false}
+>
+                  10 minutes
+</MenuItem>,
+                <MenuItem
+                  active={false}
+                  bsClass="dropdown"
+                  disabled={false}
+                  divider={false}
+                  eventKey="30m"
+                  header={false}
+>
+                  30 minutes
+</MenuItem>,
+              ],
+              "id": "rateInterval",
+              "onSelect": [Function],
+              "title": "Rate interval",
+            },
+            "ref": null,
+            "rendered": Array [
+              Object {
+                "instance": null,
+                "key": "1m",
+                "nodeType": "class",
+                "props": Object {
+                  "active": true,
+                  "bsClass": "dropdown",
+                  "children": "1 minute",
+                  "disabled": false,
+                  "divider": false,
+                  "eventKey": "1m",
+                  "header": false,
+                },
+                "ref": null,
+                "rendered": "1 minute",
+                "type": [Function],
+              },
+              Object {
+                "instance": null,
+                "key": "5m",
+                "nodeType": "class",
+                "props": Object {
+                  "active": false,
+                  "bsClass": "dropdown",
+                  "children": "5 minutes",
+                  "disabled": false,
+                  "divider": false,
+                  "eventKey": "5m",
+                  "header": false,
+                },
+                "ref": null,
+                "rendered": "5 minutes",
+                "type": [Function],
+              },
+              Object {
+                "instance": null,
+                "key": "10m",
+                "nodeType": "class",
+                "props": Object {
+                  "active": false,
+                  "bsClass": "dropdown",
+                  "children": "10 minutes",
+                  "disabled": false,
+                  "divider": false,
+                  "eventKey": "10m",
+                  "header": false,
+                },
+                "ref": null,
+                "rendered": "10 minutes",
+                "type": [Function],
+              },
+              Object {
+                "instance": null,
+                "key": "30m",
+                "nodeType": "class",
+                "props": Object {
+                  "active": false,
+                  "bsClass": "dropdown",
+                  "children": "30 minutes",
+                  "disabled": false,
+                  "divider": false,
+                  "eventKey": "30m",
+                  "header": false,
+                },
+                "ref": null,
+                "rendered": "30 minutes",
+                "type": [Function],
+              },
+            ],
+            "type": [Function],
+          },
+        ],
+        "type": "div",
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": Array [
+            <getContext(Filter)>
+              <FilterValueSelector
+                            filterValues={
+                                          Array [
+                                                        "local version",
+                                                        "remote service",
+                                                        "remote version",
+                                                        "response code",
+                                                      ]
+                            }
+                            onFilterValueSelected={[Function]}
+                            placeholder="Group by"
+              />
+</getContext(Filter)>,
+            false,
+          ],
+          "className": "form-group",
+        },
+        "ref": null,
+        "rendered": Array [
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "function",
+            "props": Object {
+              "children": <FilterValueSelector
+                filterValues={
+                                Array [
+                                                "local version",
+                                                "remote service",
+                                                "remote version",
+                                                "response code",
+                                              ]
+                }
+                onFilterValueSelected={[Function]}
+                placeholder="Group by"
+/>,
+            },
+            "ref": null,
+            "rendered": Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "function",
+              "props": Object {
+                "filterValues": Array [
+                  "local version",
+                  "remote service",
+                  "remote version",
+                  "response code",
+                ],
+                "onFilterValueSelected": [Function],
+                "placeholder": "Group by",
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
+            "type": [Function],
+          },
+          false,
+        ],
+        "type": "div",
+      },
+    ],
+    "type": [Function],
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "class",
+      "props": Object {
+        "children": Array [
+          <div
+            className="form-group"
+>
+            <DropdownButton
+                        id="duration"
+                        onSelect={[Function]}
+                        title="Duration"
+            >
+                        <MenuItem
+                                    active={false}
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    eventKey={300}
+                                    header={false}
+                        >
+                                    Last 5 minutes
+                        </MenuItem>
+                        <MenuItem
+                                    active={true}
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    eventKey={600}
+                                    header={false}
+                        >
+                                    Last 10 minutes
+                        </MenuItem>
+                        <MenuItem
+                                    active={false}
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    eventKey={1800}
+                                    header={false}
+                        >
+                                    Last 30 minutes
+                        </MenuItem>
+                        <MenuItem
+                                    active={false}
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    eventKey={3600}
+                                    header={false}
+                        >
+                                    Last hour
+                        </MenuItem>
+                        <MenuItem
+                                    active={false}
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    eventKey={10800}
+                                    header={false}
+                        >
+                                    Last 3 hours
+                        </MenuItem>
+                        <MenuItem
+                                    active={false}
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    eventKey={21600}
+                                    header={false}
+                        >
+                                    Last 6 hours
+                        </MenuItem>
+                        <MenuItem
+                                    active={false}
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    eventKey={43200}
+                                    header={false}
+                        >
+                                    Last 12 hours
+                        </MenuItem>
+                        <MenuItem
+                                    active={false}
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    eventKey={86400}
+                                    header={false}
+                        >
+                                    Last day
+                        </MenuItem>
+            </DropdownButton>
+            <DropdownButton
+                        id="ticks"
+                        onSelect={[Function]}
+                        title="Ticks"
+            >
+                        <MenuItem
+                                    active={false}
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    eventKey={10}
+                                    header={false}
+                        >
+                                    10
+                        </MenuItem>
+                        <MenuItem
+                                    active={false}
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    eventKey={20}
+                                    header={false}
+                        >
+                                    20
+                        </MenuItem>
+                        <MenuItem
+                                    active={true}
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    eventKey={30}
+                                    header={false}
+                        >
+                                    30
+                        </MenuItem>
+                        <MenuItem
+                                    active={false}
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    eventKey={50}
+                                    header={false}
+                        >
+                                    50
+                        </MenuItem>
+                        <MenuItem
+                                    active={false}
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    eventKey={100}
+                                    header={false}
+                        >
+                                    100
+                        </MenuItem>
+                        <MenuItem
+                                    active={false}
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    eventKey={200}
+                                    header={false}
+                        >
+                                    200
+                        </MenuItem>
+            </DropdownButton>
+            <DropdownButton
+                        id="rateInterval"
+                        onSelect={[Function]}
+                        title="Rate interval"
+            >
+                        <MenuItem
+                                    active={true}
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    eventKey="1m"
+                                    header={false}
+                        >
+                                    1 minute
+                        </MenuItem>
+                        <MenuItem
+                                    active={false}
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    eventKey="5m"
+                                    header={false}
+                        >
+                                    5 minutes
+                        </MenuItem>
+                        <MenuItem
+                                    active={false}
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    eventKey="10m"
+                                    header={false}
+                        >
+                                    10 minutes
+                        </MenuItem>
+                        <MenuItem
+                                    active={false}
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    eventKey="30m"
+                                    header={false}
+                        >
+                                    30 minutes
+                        </MenuItem>
+            </DropdownButton>
+</div>,
+          <div
+            className="form-group"
+>
+            <getContext(Filter)>
+                        <FilterValueSelector
+                                    filterValues={
+                                                Array [
+                                                            "local version",
+                                                            "remote service",
+                                                            "remote version",
+                                                            "response code",
+                                                          ]
+                                    }
+                                    onFilterValueSelected={[Function]}
+                                    placeholder="Group by"
+                        />
+            </getContext(Filter)>
+</div>,
+        ],
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              <DropdownButton
+                id="duration"
+                onSelect={[Function]}
+                title="Duration"
+>
+                <MenuItem
+                                active={false}
+                                bsClass="dropdown"
+                                disabled={false}
+                                divider={false}
+                                eventKey={300}
+                                header={false}
+                >
+                                Last 5 minutes
+                </MenuItem>
+                <MenuItem
+                                active={true}
+                                bsClass="dropdown"
+                                disabled={false}
+                                divider={false}
+                                eventKey={600}
+                                header={false}
+                >
+                                Last 10 minutes
+                </MenuItem>
+                <MenuItem
+                                active={false}
+                                bsClass="dropdown"
+                                disabled={false}
+                                divider={false}
+                                eventKey={1800}
+                                header={false}
+                >
+                                Last 30 minutes
+                </MenuItem>
+                <MenuItem
+                                active={false}
+                                bsClass="dropdown"
+                                disabled={false}
+                                divider={false}
+                                eventKey={3600}
+                                header={false}
+                >
+                                Last hour
+                </MenuItem>
+                <MenuItem
+                                active={false}
+                                bsClass="dropdown"
+                                disabled={false}
+                                divider={false}
+                                eventKey={10800}
+                                header={false}
+                >
+                                Last 3 hours
+                </MenuItem>
+                <MenuItem
+                                active={false}
+                                bsClass="dropdown"
+                                disabled={false}
+                                divider={false}
+                                eventKey={21600}
+                                header={false}
+                >
+                                Last 6 hours
+                </MenuItem>
+                <MenuItem
+                                active={false}
+                                bsClass="dropdown"
+                                disabled={false}
+                                divider={false}
+                                eventKey={43200}
+                                header={false}
+                >
+                                Last 12 hours
+                </MenuItem>
+                <MenuItem
+                                active={false}
+                                bsClass="dropdown"
+                                disabled={false}
+                                divider={false}
+                                eventKey={86400}
+                                header={false}
+                >
+                                Last day
+                </MenuItem>
+</DropdownButton>,
+              <DropdownButton
+                id="ticks"
+                onSelect={[Function]}
+                title="Ticks"
+>
+                <MenuItem
+                                active={false}
+                                bsClass="dropdown"
+                                disabled={false}
+                                divider={false}
+                                eventKey={10}
+                                header={false}
+                >
+                                10
+                </MenuItem>
+                <MenuItem
+                                active={false}
+                                bsClass="dropdown"
+                                disabled={false}
+                                divider={false}
+                                eventKey={20}
+                                header={false}
+                >
+                                20
+                </MenuItem>
+                <MenuItem
+                                active={true}
+                                bsClass="dropdown"
+                                disabled={false}
+                                divider={false}
+                                eventKey={30}
+                                header={false}
+                >
+                                30
+                </MenuItem>
+                <MenuItem
+                                active={false}
+                                bsClass="dropdown"
+                                disabled={false}
+                                divider={false}
+                                eventKey={50}
+                                header={false}
+                >
+                                50
+                </MenuItem>
+                <MenuItem
+                                active={false}
+                                bsClass="dropdown"
+                                disabled={false}
+                                divider={false}
+                                eventKey={100}
+                                header={false}
+                >
+                                100
+                </MenuItem>
+                <MenuItem
+                                active={false}
+                                bsClass="dropdown"
+                                disabled={false}
+                                divider={false}
+                                eventKey={200}
+                                header={false}
+                >
+                                200
+                </MenuItem>
+</DropdownButton>,
+              <DropdownButton
+                id="rateInterval"
+                onSelect={[Function]}
+                title="Rate interval"
+>
+                <MenuItem
+                                active={true}
+                                bsClass="dropdown"
+                                disabled={false}
+                                divider={false}
+                                eventKey="1m"
+                                header={false}
+                >
+                                1 minute
+                </MenuItem>
+                <MenuItem
+                                active={false}
+                                bsClass="dropdown"
+                                disabled={false}
+                                divider={false}
+                                eventKey="5m"
+                                header={false}
+                >
+                                5 minutes
+                </MenuItem>
+                <MenuItem
+                                active={false}
+                                bsClass="dropdown"
+                                disabled={false}
+                                divider={false}
+                                eventKey="10m"
+                                header={false}
+                >
+                                10 minutes
+                </MenuItem>
+                <MenuItem
+                                active={false}
+                                bsClass="dropdown"
+                                disabled={false}
+                                divider={false}
+                                eventKey="30m"
+                                header={false}
+                >
+                                30 minutes
+                </MenuItem>
+</DropdownButton>,
+            ],
+            "className": "form-group",
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "function",
+              "props": Object {
+                "children": Array [
+                  <MenuItem
+                    active={false}
+                    bsClass="dropdown"
+                    disabled={false}
+                    divider={false}
+                    eventKey={300}
+                    header={false}
+>
+                    Last 5 minutes
+</MenuItem>,
+                  <MenuItem
+                    active={true}
+                    bsClass="dropdown"
+                    disabled={false}
+                    divider={false}
+                    eventKey={600}
+                    header={false}
+>
+                    Last 10 minutes
+</MenuItem>,
+                  <MenuItem
+                    active={false}
+                    bsClass="dropdown"
+                    disabled={false}
+                    divider={false}
+                    eventKey={1800}
+                    header={false}
+>
+                    Last 30 minutes
+</MenuItem>,
+                  <MenuItem
+                    active={false}
+                    bsClass="dropdown"
+                    disabled={false}
+                    divider={false}
+                    eventKey={3600}
+                    header={false}
+>
+                    Last hour
+</MenuItem>,
+                  <MenuItem
+                    active={false}
+                    bsClass="dropdown"
+                    disabled={false}
+                    divider={false}
+                    eventKey={10800}
+                    header={false}
+>
+                    Last 3 hours
+</MenuItem>,
+                  <MenuItem
+                    active={false}
+                    bsClass="dropdown"
+                    disabled={false}
+                    divider={false}
+                    eventKey={21600}
+                    header={false}
+>
+                    Last 6 hours
+</MenuItem>,
+                  <MenuItem
+                    active={false}
+                    bsClass="dropdown"
+                    disabled={false}
+                    divider={false}
+                    eventKey={43200}
+                    header={false}
+>
+                    Last 12 hours
+</MenuItem>,
+                  <MenuItem
+                    active={false}
+                    bsClass="dropdown"
+                    disabled={false}
+                    divider={false}
+                    eventKey={86400}
+                    header={false}
+>
+                    Last day
+</MenuItem>,
+                ],
+                "id": "duration",
+                "onSelect": [Function],
+                "title": "Duration",
+              },
+              "ref": null,
+              "rendered": Array [
+                Object {
+                  "instance": null,
+                  "key": "300",
+                  "nodeType": "class",
+                  "props": Object {
+                    "active": false,
+                    "bsClass": "dropdown",
+                    "children": "Last 5 minutes",
+                    "disabled": false,
+                    "divider": false,
+                    "eventKey": 300,
+                    "header": false,
+                  },
+                  "ref": null,
+                  "rendered": "Last 5 minutes",
+                  "type": [Function],
+                },
+                Object {
+                  "instance": null,
+                  "key": "600",
+                  "nodeType": "class",
+                  "props": Object {
+                    "active": true,
+                    "bsClass": "dropdown",
+                    "children": "Last 10 minutes",
+                    "disabled": false,
+                    "divider": false,
+                    "eventKey": 600,
+                    "header": false,
+                  },
+                  "ref": null,
+                  "rendered": "Last 10 minutes",
+                  "type": [Function],
+                },
+                Object {
+                  "instance": null,
+                  "key": "1800",
+                  "nodeType": "class",
+                  "props": Object {
+                    "active": false,
+                    "bsClass": "dropdown",
+                    "children": "Last 30 minutes",
+                    "disabled": false,
+                    "divider": false,
+                    "eventKey": 1800,
+                    "header": false,
+                  },
+                  "ref": null,
+                  "rendered": "Last 30 minutes",
+                  "type": [Function],
+                },
+                Object {
+                  "instance": null,
+                  "key": "3600",
+                  "nodeType": "class",
+                  "props": Object {
+                    "active": false,
+                    "bsClass": "dropdown",
+                    "children": "Last hour",
+                    "disabled": false,
+                    "divider": false,
+                    "eventKey": 3600,
+                    "header": false,
+                  },
+                  "ref": null,
+                  "rendered": "Last hour",
+                  "type": [Function],
+                },
+                Object {
+                  "instance": null,
+                  "key": "10800",
+                  "nodeType": "class",
+                  "props": Object {
+                    "active": false,
+                    "bsClass": "dropdown",
+                    "children": "Last 3 hours",
+                    "disabled": false,
+                    "divider": false,
+                    "eventKey": 10800,
+                    "header": false,
+                  },
+                  "ref": null,
+                  "rendered": "Last 3 hours",
+                  "type": [Function],
+                },
+                Object {
+                  "instance": null,
+                  "key": "21600",
+                  "nodeType": "class",
+                  "props": Object {
+                    "active": false,
+                    "bsClass": "dropdown",
+                    "children": "Last 6 hours",
+                    "disabled": false,
+                    "divider": false,
+                    "eventKey": 21600,
+                    "header": false,
+                  },
+                  "ref": null,
+                  "rendered": "Last 6 hours",
+                  "type": [Function],
+                },
+                Object {
+                  "instance": null,
+                  "key": "43200",
+                  "nodeType": "class",
+                  "props": Object {
+                    "active": false,
+                    "bsClass": "dropdown",
+                    "children": "Last 12 hours",
+                    "disabled": false,
+                    "divider": false,
+                    "eventKey": 43200,
+                    "header": false,
+                  },
+                  "ref": null,
+                  "rendered": "Last 12 hours",
+                  "type": [Function],
+                },
+                Object {
+                  "instance": null,
+                  "key": "86400",
+                  "nodeType": "class",
+                  "props": Object {
+                    "active": false,
+                    "bsClass": "dropdown",
+                    "children": "Last day",
+                    "disabled": false,
+                    "divider": false,
+                    "eventKey": 86400,
+                    "header": false,
+                  },
+                  "ref": null,
+                  "rendered": "Last day",
+                  "type": [Function],
+                },
+              ],
+              "type": [Function],
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "function",
+              "props": Object {
+                "children": Array [
+                  <MenuItem
+                    active={false}
+                    bsClass="dropdown"
+                    disabled={false}
+                    divider={false}
+                    eventKey={10}
+                    header={false}
+>
+                    10
+</MenuItem>,
+                  <MenuItem
+                    active={false}
+                    bsClass="dropdown"
+                    disabled={false}
+                    divider={false}
+                    eventKey={20}
+                    header={false}
+>
+                    20
+</MenuItem>,
+                  <MenuItem
+                    active={true}
+                    bsClass="dropdown"
+                    disabled={false}
+                    divider={false}
+                    eventKey={30}
+                    header={false}
+>
+                    30
+</MenuItem>,
+                  <MenuItem
+                    active={false}
+                    bsClass="dropdown"
+                    disabled={false}
+                    divider={false}
+                    eventKey={50}
+                    header={false}
+>
+                    50
+</MenuItem>,
+                  <MenuItem
+                    active={false}
+                    bsClass="dropdown"
+                    disabled={false}
+                    divider={false}
+                    eventKey={100}
+                    header={false}
+>
+                    100
+</MenuItem>,
+                  <MenuItem
+                    active={false}
+                    bsClass="dropdown"
+                    disabled={false}
+                    divider={false}
+                    eventKey={200}
+                    header={false}
+>
+                    200
+</MenuItem>,
+                ],
+                "id": "ticks",
+                "onSelect": [Function],
+                "title": "Ticks",
+              },
+              "ref": null,
+              "rendered": Array [
+                Object {
+                  "instance": null,
+                  "key": "10",
+                  "nodeType": "class",
+                  "props": Object {
+                    "active": false,
+                    "bsClass": "dropdown",
+                    "children": 10,
+                    "disabled": false,
+                    "divider": false,
+                    "eventKey": 10,
+                    "header": false,
+                  },
+                  "ref": null,
+                  "rendered": 10,
+                  "type": [Function],
+                },
+                Object {
+                  "instance": null,
+                  "key": "20",
+                  "nodeType": "class",
+                  "props": Object {
+                    "active": false,
+                    "bsClass": "dropdown",
+                    "children": 20,
+                    "disabled": false,
+                    "divider": false,
+                    "eventKey": 20,
+                    "header": false,
+                  },
+                  "ref": null,
+                  "rendered": 20,
+                  "type": [Function],
+                },
+                Object {
+                  "instance": null,
+                  "key": "30",
+                  "nodeType": "class",
+                  "props": Object {
+                    "active": true,
+                    "bsClass": "dropdown",
+                    "children": 30,
+                    "disabled": false,
+                    "divider": false,
+                    "eventKey": 30,
+                    "header": false,
+                  },
+                  "ref": null,
+                  "rendered": 30,
+                  "type": [Function],
+                },
+                Object {
+                  "instance": null,
+                  "key": "50",
+                  "nodeType": "class",
+                  "props": Object {
+                    "active": false,
+                    "bsClass": "dropdown",
+                    "children": 50,
+                    "disabled": false,
+                    "divider": false,
+                    "eventKey": 50,
+                    "header": false,
+                  },
+                  "ref": null,
+                  "rendered": 50,
+                  "type": [Function],
+                },
+                Object {
+                  "instance": null,
+                  "key": "100",
+                  "nodeType": "class",
+                  "props": Object {
+                    "active": false,
+                    "bsClass": "dropdown",
+                    "children": 100,
+                    "disabled": false,
+                    "divider": false,
+                    "eventKey": 100,
+                    "header": false,
+                  },
+                  "ref": null,
+                  "rendered": 100,
+                  "type": [Function],
+                },
+                Object {
+                  "instance": null,
+                  "key": "200",
+                  "nodeType": "class",
+                  "props": Object {
+                    "active": false,
+                    "bsClass": "dropdown",
+                    "children": 200,
+                    "disabled": false,
+                    "divider": false,
+                    "eventKey": 200,
+                    "header": false,
+                  },
+                  "ref": null,
+                  "rendered": 200,
+                  "type": [Function],
+                },
+              ],
+              "type": [Function],
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "function",
+              "props": Object {
+                "children": Array [
+                  <MenuItem
+                    active={true}
+                    bsClass="dropdown"
+                    disabled={false}
+                    divider={false}
+                    eventKey="1m"
+                    header={false}
+>
+                    1 minute
+</MenuItem>,
+                  <MenuItem
+                    active={false}
+                    bsClass="dropdown"
+                    disabled={false}
+                    divider={false}
+                    eventKey="5m"
+                    header={false}
+>
+                    5 minutes
+</MenuItem>,
+                  <MenuItem
+                    active={false}
+                    bsClass="dropdown"
+                    disabled={false}
+                    divider={false}
+                    eventKey="10m"
+                    header={false}
+>
+                    10 minutes
+</MenuItem>,
+                  <MenuItem
+                    active={false}
+                    bsClass="dropdown"
+                    disabled={false}
+                    divider={false}
+                    eventKey="30m"
+                    header={false}
+>
+                    30 minutes
+</MenuItem>,
+                ],
+                "id": "rateInterval",
+                "onSelect": [Function],
+                "title": "Rate interval",
+              },
+              "ref": null,
+              "rendered": Array [
+                Object {
+                  "instance": null,
+                  "key": "1m",
+                  "nodeType": "class",
+                  "props": Object {
+                    "active": true,
+                    "bsClass": "dropdown",
+                    "children": "1 minute",
+                    "disabled": false,
+                    "divider": false,
+                    "eventKey": "1m",
+                    "header": false,
+                  },
+                  "ref": null,
+                  "rendered": "1 minute",
+                  "type": [Function],
+                },
+                Object {
+                  "instance": null,
+                  "key": "5m",
+                  "nodeType": "class",
+                  "props": Object {
+                    "active": false,
+                    "bsClass": "dropdown",
+                    "children": "5 minutes",
+                    "disabled": false,
+                    "divider": false,
+                    "eventKey": "5m",
+                    "header": false,
+                  },
+                  "ref": null,
+                  "rendered": "5 minutes",
+                  "type": [Function],
+                },
+                Object {
+                  "instance": null,
+                  "key": "10m",
+                  "nodeType": "class",
+                  "props": Object {
+                    "active": false,
+                    "bsClass": "dropdown",
+                    "children": "10 minutes",
+                    "disabled": false,
+                    "divider": false,
+                    "eventKey": "10m",
+                    "header": false,
+                  },
+                  "ref": null,
+                  "rendered": "10 minutes",
+                  "type": [Function],
+                },
+                Object {
+                  "instance": null,
+                  "key": "30m",
+                  "nodeType": "class",
+                  "props": Object {
+                    "active": false,
+                    "bsClass": "dropdown",
+                    "children": "30 minutes",
+                    "disabled": false,
+                    "divider": false,
+                    "eventKey": "30m",
+                    "header": false,
+                  },
+                  "ref": null,
+                  "rendered": "30 minutes",
+                  "type": [Function],
+                },
+              ],
+              "type": [Function],
+            },
+          ],
+          "type": "div",
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              <getContext(Filter)>
+                <FilterValueSelector
+                                filterValues={
+                                                Array [
+                                                                "local version",
+                                                                "remote service",
+                                                                "remote version",
+                                                                "response code",
+                                                              ]
+                                }
+                                onFilterValueSelected={[Function]}
+                                placeholder="Group by"
+                />
+</getContext(Filter)>,
+              false,
+            ],
+            "className": "form-group",
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "function",
+              "props": Object {
+                "children": <FilterValueSelector
+                  filterValues={
+                                    Array [
+                                                      "local version",
+                                                      "remote service",
+                                                      "remote version",
+                                                      "response code",
+                                                    ]
+                  }
+                  onFilterValueSelected={[Function]}
+                  placeholder="Group by"
+/>,
+              },
+              "ref": null,
+              "rendered": Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "function",
+                "props": Object {
+                  "filterValues": Array [
+                    "local version",
+                    "remote service",
+                    "remote version",
+                    "response code",
+                  ],
+                  "onFilterValueSelected": [Function],
+                  "placeholder": "Group by",
+                },
+                "ref": null,
+                "rendered": null,
+                "type": [Function],
+              },
+              "type": [Function],
+            },
+            false,
+          ],
+          "type": "div",
+        },
+      ],
+      "type": [Function],
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;

--- a/src/components/MetricsOptions/__tests__/__snapshots__/MetricsOptionsBar.test.tsx.snap
+++ b/src/components/MetricsOptions/__tests__/__snapshots__/MetricsOptionsBar.test.tsx.snap
@@ -20,6 +20,20 @@ ShallowWrapper {
     "nodeType": "class",
     "props": Object {
       "children": Array [
+        <getContext(Filter)>
+          <FilterValueSelector
+                    filterValues={
+                              Array [
+                                        "local version",
+                                        "remote service",
+                                        "remote version",
+                                        "response code",
+                                      ]
+                    }
+                    onFilterValueSelected={[Function]}
+                    placeholder="Group by"
+          />
+</getContext(Filter)>,
         <div
           className="form-group"
 >
@@ -222,28 +236,50 @@ ShallowWrapper {
                     </MenuItem>
           </DropdownButton>
 </div>,
-        <div
-          className="form-group"
->
-          <getContext(Filter)>
-                    <FilterValueSelector
-                              filterValues={
-                                        Array [
-                                                  "local version",
-                                                  "remote service",
-                                                  "remote version",
-                                                  "response code",
-                                                ]
-                              }
-                              onFilterValueSelected={[Function]}
-                              placeholder="Group by"
-                    />
-          </getContext(Filter)>
-</div>,
+        false,
       ],
     },
     "ref": null,
     "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "function",
+        "props": Object {
+          "children": <FilterValueSelector
+            filterValues={
+                        Array [
+                                    "local version",
+                                    "remote service",
+                                    "remote version",
+                                    "response code",
+                                  ]
+            }
+            onFilterValueSelected={[Function]}
+            placeholder="Group by"
+/>,
+        },
+        "ref": null,
+        "rendered": Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "function",
+          "props": Object {
+            "filterValues": Array [
+              "local version",
+              "remote service",
+              "remote version",
+              "response code",
+            ],
+            "onFilterValueSelected": [Function],
+            "placeholder": "Group by",
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+        "type": [Function],
+      },
       Object {
         "instance": null,
         "key": undefined,
@@ -990,75 +1026,7 @@ ShallowWrapper {
         ],
         "type": "div",
       },
-      Object {
-        "instance": null,
-        "key": undefined,
-        "nodeType": "host",
-        "props": Object {
-          "children": Array [
-            <getContext(Filter)>
-              <FilterValueSelector
-                            filterValues={
-                                          Array [
-                                                        "local version",
-                                                        "remote service",
-                                                        "remote version",
-                                                        "response code",
-                                                      ]
-                            }
-                            onFilterValueSelected={[Function]}
-                            placeholder="Group by"
-              />
-</getContext(Filter)>,
-            false,
-          ],
-          "className": "form-group",
-        },
-        "ref": null,
-        "rendered": Array [
-          Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "function",
-            "props": Object {
-              "children": <FilterValueSelector
-                filterValues={
-                                Array [
-                                                "local version",
-                                                "remote service",
-                                                "remote version",
-                                                "response code",
-                                              ]
-                }
-                onFilterValueSelected={[Function]}
-                placeholder="Group by"
-/>,
-            },
-            "ref": null,
-            "rendered": Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "function",
-              "props": Object {
-                "filterValues": Array [
-                  "local version",
-                  "remote service",
-                  "remote version",
-                  "response code",
-                ],
-                "onFilterValueSelected": [Function],
-                "placeholder": "Group by",
-              },
-              "ref": null,
-              "rendered": null,
-              "type": [Function],
-            },
-            "type": [Function],
-          },
-          false,
-        ],
-        "type": "div",
-      },
+      false,
     ],
     "type": [Function],
   },
@@ -1069,6 +1037,20 @@ ShallowWrapper {
       "nodeType": "class",
       "props": Object {
         "children": Array [
+          <getContext(Filter)>
+            <FilterValueSelector
+                        filterValues={
+                                    Array [
+                                                "local version",
+                                                "remote service",
+                                                "remote version",
+                                                "response code",
+                                              ]
+                        }
+                        onFilterValueSelected={[Function]}
+                        placeholder="Group by"
+            />
+</getContext(Filter)>,
           <div
             className="form-group"
 >
@@ -1271,28 +1253,50 @@ ShallowWrapper {
                         </MenuItem>
             </DropdownButton>
 </div>,
-          <div
-            className="form-group"
->
-            <getContext(Filter)>
-                        <FilterValueSelector
-                                    filterValues={
-                                                Array [
-                                                            "local version",
-                                                            "remote service",
-                                                            "remote version",
-                                                            "response code",
-                                                          ]
-                                    }
-                                    onFilterValueSelected={[Function]}
-                                    placeholder="Group by"
-                        />
-            </getContext(Filter)>
-</div>,
+          false,
         ],
       },
       "ref": null,
       "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "function",
+          "props": Object {
+            "children": <FilterValueSelector
+              filterValues={
+                            Array [
+                                          "local version",
+                                          "remote service",
+                                          "remote version",
+                                          "response code",
+                                        ]
+              }
+              onFilterValueSelected={[Function]}
+              placeholder="Group by"
+/>,
+          },
+          "ref": null,
+          "rendered": Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "function",
+            "props": Object {
+              "filterValues": Array [
+                "local version",
+                "remote service",
+                "remote version",
+                "response code",
+              ],
+              "onFilterValueSelected": [Function],
+              "placeholder": "Group by",
+            },
+            "ref": null,
+            "rendered": null,
+            "type": [Function],
+          },
+          "type": [Function],
+        },
         Object {
           "instance": null,
           "key": undefined,
@@ -2039,75 +2043,7 @@ ShallowWrapper {
           ],
           "type": "div",
         },
-        Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "host",
-          "props": Object {
-            "children": Array [
-              <getContext(Filter)>
-                <FilterValueSelector
-                                filterValues={
-                                                Array [
-                                                                "local version",
-                                                                "remote service",
-                                                                "remote version",
-                                                                "response code",
-                                                              ]
-                                }
-                                onFilterValueSelected={[Function]}
-                                placeholder="Group by"
-                />
-</getContext(Filter)>,
-              false,
-            ],
-            "className": "form-group",
-          },
-          "ref": null,
-          "rendered": Array [
-            Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "function",
-              "props": Object {
-                "children": <FilterValueSelector
-                  filterValues={
-                                    Array [
-                                                      "local version",
-                                                      "remote service",
-                                                      "remote version",
-                                                      "response code",
-                                                    ]
-                  }
-                  onFilterValueSelected={[Function]}
-                  placeholder="Group by"
-/>,
-              },
-              "ref": null,
-              "rendered": Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "function",
-                "props": Object {
-                  "filterValues": Array [
-                    "local version",
-                    "remote service",
-                    "remote version",
-                    "response code",
-                  ],
-                  "onFilterValueSelected": [Function],
-                  "placeholder": "Group by",
-                },
-                "ref": null,
-                "rendered": null,
-                "type": [Function],
-              },
-              "type": [Function],
-            },
-            false,
-          ],
-          "type": "div",
-        },
+        false,
       ],
       "type": [Function],
     },

--- a/src/pages/ServiceDetails/ServiceMetrics.tsx
+++ b/src/pages/ServiceDetails/ServiceMetrics.tsx
@@ -3,7 +3,7 @@ import ServiceId from '../../types/ServiceId';
 import * as M from '../../types/Metrics';
 import * as API from '../../services/Api';
 import MetricsOptionsBar from '../../components/MetricsOptions/MetricsOptionsBar';
-import { MetricsOptions } from '../../types/MetricsOptions';
+import MetricsOptions from '../../types/MetricsOptions';
 import { Spinner, LineChart, DonutChart } from 'patternfly-react';
 
 interface GrafanaInfo {

--- a/src/pages/ServiceDetails/ServiceMetrics.tsx
+++ b/src/pages/ServiceDetails/ServiceMetrics.tsx
@@ -25,7 +25,8 @@ type ServiceMetricsState = {
   responseSizeIn?: M.Histogram;
   responseSizeOut?: M.Histogram;
   health?: M.Health;
-  grafanaInfo?: GrafanaInfo;
+  grafanaLinkIn?: string;
+  grafanaLinkOut?: string;
 };
 
 class ServiceMetrics extends React.Component<ServiceId, ServiceMetricsState> {
@@ -63,14 +64,46 @@ class ServiceMetrics extends React.Component<ServiceId, ServiceMetricsState> {
         const metrics: M.Metrics = response['data'];
         this.setState({
           loading: false,
-          requestCountIn: metrics.metrics['request_count_in'],
-          requestCountOut: metrics.metrics['request_count_out'],
-          requestSizeIn: metrics.histograms['request_size_in'],
-          requestSizeOut: metrics.histograms['request_size_out'],
-          requestDurationIn: metrics.histograms['request_duration_in'],
-          requestDurationOut: metrics.histograms['request_duration_out'],
-          responseSizeIn: metrics.histograms['response_size_in'],
-          responseSizeOut: metrics.histograms['response_size_out'],
+          requestCountIn: this.nameMetric(
+            metrics.metrics['request_count_in'],
+            'Request volume (ops)',
+            options.byLabelsIn
+          ),
+          requestCountOut: this.nameMetric(
+            metrics.metrics['request_count_out'],
+            'Request volume (ops)',
+            options.byLabelsOut
+          ),
+          requestSizeIn: this.nameHistogram(
+            metrics.histograms['request_size_in'],
+            'Request size (bytes)',
+            options.byLabelsIn
+          ),
+          requestSizeOut: this.nameHistogram(
+            metrics.histograms['request_size_out'],
+            'Request size (bytes)',
+            options.byLabelsOut
+          ),
+          requestDurationIn: this.nameHistogram(
+            metrics.histograms['request_duration_in'],
+            'Request duration (seconds)',
+            options.byLabelsIn
+          ),
+          requestDurationOut: this.nameHistogram(
+            metrics.histograms['request_duration_out'],
+            'Request duration (seconds)',
+            options.byLabelsOut
+          ),
+          responseSizeIn: this.nameHistogram(
+            metrics.histograms['response_size_in'],
+            'Response size (bytes)',
+            options.byLabelsIn
+          ),
+          responseSizeOut: this.nameHistogram(
+            metrics.histograms['response_size_out'],
+            'Response size (bytes)',
+            options.byLabelsOut
+          ),
           health: metrics.health
         });
       })
@@ -81,19 +114,56 @@ class ServiceMetrics extends React.Component<ServiceId, ServiceMetricsState> {
       });
   }
 
+  nameMetric(metric: M.MetricGroup, familyName: string, labels: string[]): M.MetricGroup {
+    if (metric) {
+      metric.familyName = familyName;
+      metric.matrix.forEach(ts => {
+        if (labels.length === 0) {
+          ts.name = familyName;
+        } else {
+          const strLabels = labels.map(lbl => ts.metric[lbl]).join(',');
+          ts.name = `${familyName}{${strLabels}}`;
+        }
+      });
+    }
+    return metric;
+  }
+
+  nameHistogram(histo: M.Histogram, familyName: string, labels: string[]): M.Histogram {
+    if (histo) {
+      histo.familyName = familyName;
+      histo.average = this.nameMetric(histo.average, familyName + '[avg]', labels);
+      histo.median = this.nameMetric(histo.median, familyName + '[med]', labels);
+      histo.percentile95 = this.nameMetric(histo.percentile95, familyName + '[p95]', labels);
+      histo.percentile99 = this.nameMetric(histo.percentile99, familyName + '[p99]', labels);
+    }
+    return histo;
+  }
+
   getGrafanaInfo() {
     API.getGrafanaInfo()
       .then(response => {
-        if (response['data']) {
-          this.setState({ grafanaInfo: response['data'] });
+        const info: GrafanaInfo = response['data'];
+        if (info) {
+          this.setState({
+            grafanaLinkIn: this.getGrafanaLink(info, false),
+            grafanaLinkOut: this.getGrafanaLink(info, true)
+          });
         } else {
-          this.setState({ grafanaInfo: undefined });
+          this.setState({ grafanaLinkIn: undefined, grafanaLinkOut: undefined });
         }
       })
       .catch(error => {
-        this.setState({ grafanaInfo: undefined });
+        this.setState({ grafanaLinkIn: undefined, grafanaLinkOut: undefined });
         console.error(error);
       });
+  }
+
+  getGrafanaLink(info: GrafanaInfo, isSource: boolean): string {
+    const varName = isSource ? info.varServiceSource : info.varServiceDest;
+    return `${info.url}/dashboard/db/${info.dashboard}?${varName}=${this.props.service}.${this.props.namespace}.${
+      info.variablesSuffix
+    }`;
   }
 
   health() {
@@ -108,22 +178,6 @@ class ServiceMetrics extends React.Component<ServiceId, ServiceMetricsState> {
       };
     }
     return null;
-  }
-
-  metricToString(group?: M.MetricGroup): string {
-    if (group && group.matrix.length > 0 && group.matrix[0].values.length > 0) {
-      const dp = group.matrix[0].values[group.matrix[0].values.length - 1];
-      return String(this.round(dp[1]));
-    }
-    return 'n/a';
-  }
-
-  histogramToString(hist?: M.Histogram): string {
-    if (hist) {
-      return `avg: ${this.metricToString(hist.average)}; med: ${this.metricToString(hist.median)}; 95th:
-        ${this.metricToString(hist.percentile95)}; 99th: ${this.metricToString(hist.percentile99)}`;
-    }
-    return 'n/a';
   }
 
   round(val: number): number {
@@ -165,12 +219,16 @@ class ServiceMetrics extends React.Component<ServiceId, ServiceMetricsState> {
                 Input
               </h3>
               <div className="card-pf-body">
-                {this.renderMetric('requestCountIn', 'Request count rate', this.state.requestCountIn)}
-                {this.renderHistogram('requestSizeIn', 'Request size', this.state.requestSizeIn)}
-                {this.renderHistogram('requestDurationIn', 'Request duration', this.state.requestDurationIn)}
-                {this.renderHistogram('responseSizeIn', 'Response size', this.state.responseSizeIn)}
+                {this.renderMetric('requestCountIn', this.state.requestCountIn)}
+                {this.renderHistogram('requestSizeIn', this.state.requestSizeIn)}
+                {this.renderHistogram('requestDurationIn', this.state.requestDurationIn)}
+                {this.renderHistogram('responseSizeIn', this.state.responseSizeIn)}
               </div>
-              {this.renderGrafanaLink(false)}
+              {this.state.grafanaLinkIn && (
+                <span id="grafana-in-link">
+                  <a href={this.state.grafanaLinkIn}>View in Grafana</a>
+                </span>
+              )}
             </div>
           </div>
           <div className="col-xs-6">
@@ -180,12 +238,16 @@ class ServiceMetrics extends React.Component<ServiceId, ServiceMetricsState> {
                 Output
               </h3>
               <ul className="card-pf-body">
-                {this.renderMetric('requestCountOut', 'Request count rate', this.state.requestCountOut)}
-                {this.renderHistogram('requestSizeOut', 'Request size', this.state.requestSizeOut)}
-                {this.renderHistogram('requestDurationOut', 'Request duration', this.state.requestDurationOut)}
-                {this.renderHistogram('responseSizeOut', 'Response size', this.state.responseSizeOut)}
+                {this.renderMetric('requestCountOut', this.state.requestCountOut)}
+                {this.renderHistogram('requestSizeOut', this.state.requestSizeOut)}
+                {this.renderHistogram('requestDurationOut', this.state.requestDurationOut)}
+                {this.renderHistogram('responseSizeOut', this.state.responseSizeOut)}
               </ul>
-              {this.renderGrafanaLink(true)}
+              {this.state.grafanaLinkOut && (
+                <span id="grafana-out-link">
+                  <a href={this.state.grafanaLinkOut}>View in Grafana</a>
+                </span>
+              )}
             </div>
           </div>
         </div>
@@ -214,20 +276,20 @@ class ServiceMetrics extends React.Component<ServiceId, ServiceMetricsState> {
     return <div />;
   }
 
-  renderMetric(id: string, title: string, metric?: M.MetricGroup) {
+  renderMetric(id: string, metric?: M.MetricGroup) {
     if (metric) {
-      return this.renderChart(id, title, this.toC3Columns(metric.matrix, title));
+      return this.renderChart(id, metric.familyName, this.toC3Columns(metric.matrix));
     }
     return <div />;
   }
 
-  renderHistogram(id: string, title: string, histo?: M.Histogram) {
+  renderHistogram(id: string, histo?: M.Histogram) {
     if (histo) {
-      const columns = this.toC3Columns(histo.average.matrix, title + ' [avg]')
-        .concat(this.toC3Columns(histo.median.matrix, title + ' [med]'))
-        .concat(this.toC3Columns(histo.percentile95.matrix, title + ' [p95]'))
-        .concat(this.toC3Columns(histo.percentile99.matrix, title + ' [p99]'));
-      return this.renderChart(id, title, columns);
+      const columns = this.toC3Columns(histo.average.matrix)
+        .concat(this.toC3Columns(histo.median.matrix))
+        .concat(this.toC3Columns(histo.percentile95.matrix))
+        .concat(this.toC3Columns(histo.percentile99.matrix));
+      return this.renderChart(id, histo.familyName, columns);
     }
     return <div />;
   }
@@ -251,7 +313,7 @@ class ServiceMetrics extends React.Component<ServiceId, ServiceMetricsState> {
     return <LineChart id={id} title={{ text: title }} data={data} axis={axis} point={{ show: false }} />;
   }
 
-  toC3Columns(matrix: M.TimeSeries[], title: string): [string, number][] {
+  toC3Columns(matrix: M.TimeSeries[]): [string, number][] {
     return matrix
       .map(mat => {
         let xseries: any = ['x'];
@@ -259,25 +321,10 @@ class ServiceMetrics extends React.Component<ServiceId, ServiceMetricsState> {
       })
       .concat(
         matrix.map(mat => {
-          let yseries: any = [title];
+          let yseries: any = [mat.name];
           return yseries.concat(mat.values.map(dp => dp[1]));
         })
       );
-  }
-
-  renderGrafanaLink(isSource: boolean) {
-    if (this.state.grafanaInfo) {
-      const varName = isSource ? this.state.grafanaInfo.varServiceSource : this.state.grafanaInfo.varServiceDest;
-      const link = `${this.state.grafanaInfo.url}/dashboard/db/${this.state.grafanaInfo.dashboard}?${varName}=${
-        this.props.service
-      }.${this.props.namespace}.${this.state.grafanaInfo.variablesSuffix}`;
-      return (
-        <span id={'grafana-' + (isSource ? 'source' : 'destination') + '-link'}>
-          <a href={link}>View in Grafana</a>
-        </span>
-      );
-    }
-    return null;
   }
 }
 

--- a/src/pages/ServiceDetails/__tests__/ServiceMetrics.test.tsx
+++ b/src/pages/ServiceDetails/__tests__/ServiceMetrics.test.tsx
@@ -69,10 +69,17 @@ describe('ServiceMetrics', () => {
       })
         .then(() => {
           mounted!.update();
-          expect(mounted!.find('#grafana-source-link > a').map(div => div.getElement().props)).toEqual([
+          expect(mounted!.find('#grafana-out-link > a').map(div => div.getElement().props)).toEqual([
             {
               children: 'View in Grafana',
               href: 'http://172.30.139.113:3000/dashboard/db/istio-dashboard?var-source=svc.ns.svc.cluster.local'
+            }
+          ]);
+          expect(mounted!.find('#grafana-in-link > a').map(div => div.getElement().props)).toEqual([
+            {
+              children: 'View in Grafana',
+              href:
+                'http://172.30.139.113:3000/dashboard/db/istio-dashboard?var-http_destination=svc.ns.svc.cluster.local'
             }
           ]);
         })

--- a/src/types/Metrics.ts
+++ b/src/types/Metrics.ts
@@ -14,15 +14,18 @@ export interface Histogram {
   median: MetricGroup;
   percentile95: MetricGroup;
   percentile99: MetricGroup;
+  familyName: string;
 }
 
 export interface MetricGroup {
   matrix: TimeSeries[];
+  familyName: string;
 }
 
 export interface TimeSeries {
   metric: Map<String, String>;
   values: Datapoint[];
+  name: string;
 }
 
 // First is timestamp, second is value

--- a/src/types/MetricsOptions.ts
+++ b/src/types/MetricsOptions.ts
@@ -1,7 +1,8 @@
 export interface MetricsOptions {
   rateInterval: string;
-  duration: string;
-  step: string;
-  filterLabels: Map<String, String>;
-  byLabels: String[];
+  duration: number;
+  step: number;
+  filterLabels: [string, string][];
+  byLabelsIn: string[];
+  byLabelsOut: string[];
 }

--- a/src/types/MetricsOptions.ts
+++ b/src/types/MetricsOptions.ts
@@ -1,4 +1,4 @@
-export interface MetricsOptions {
+interface MetricsOptions {
   rateInterval: string;
   duration: number;
   step: number;
@@ -6,3 +6,5 @@ export interface MetricsOptions {
   byLabelsIn: string[];
   byLabelsOut: string[];
 }
+
+export default MetricsOptions;


### PR DESCRIPTION
- allow grouping by label
- add unit to charts
- some refactoring in MetricService to compute as few as possible during rendering
- replace option "step" with "ticks", to prevent having too many datapoints freezing the browser when we have low step + high duration. Step = duration / ticks

Screenshot: https://screenshots.firefox.com/vO3BZbotsIKtJA5I/localhost