### PR TITLE
SWS-322 Make service graph text more readable

### DIFF
--- a/src/components/CytoscapeLayout/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeLayout/graphs/GraphStyles.ts
@@ -16,8 +16,9 @@ export class GraphStyles {
           'border-width': '1px',
           'border-color': '#000',
           'font-size': '10px',
-          'text-valign': 'center',
-          'text-halign': 'right'
+          'text-valign': 'bottom',
+          'text-halign': 'right',
+          'text-outline-color': '#77828C'
         }
       },
       {
@@ -51,6 +52,7 @@ export class GraphStyles {
           width: 3,
           color: '#434343',
           'font-size': '8px',
+          'text-margin-x': '25px',
           content: 'data(text)',
           'target-arrow-shape': 'vee',
           'line-color': 'data(color)',


### PR DESCRIPTION
Make service graph labels text more readable via:

- give more space between edge/node and label text
- make edge label text a bit smaller font
- make edge label text gray instead of black

<img width="677" alt="cola" src="https://user-images.githubusercontent.com/1312165/37422909-b0039478-2779-11e8-9038-ac7744bf385b.png">

<img width="650" alt="dagre" src="https://user-images.githubusercontent.com/1312165/37422953-d1d8c708-2779-11e8-97af-b5123a81f411.png">

<img width="658" alt="breadthfirst" src="https://user-images.githubusercontent.com/1312165/37422996-efacd184-2779-11e8-8390-79b910f4b398.png">

https://issues.jboss.org/browse/SWS-322
