### PR TITLE
Add tslint rule for only ES6 arrow functions (no function syntax)

### DIFF
--- a/src/components/CytoscapeLayout/graphs/GraphHighlighter.ts
+++ b/src/components/CytoscapeLayout/graphs/GraphHighlighter.ts
@@ -90,7 +90,7 @@ export class GraphHighlighter {
     this.cy
       .elements()
       .difference(toHighlight)
-      .filter(function(ele: any) {
+      .filter((ele: any) => {
         return !ele.isParent();
       })
       .addClass(DIM_CLASS);

--- a/src/components/ServiceFilter/ServiceFilter.tsx
+++ b/src/components/ServiceFilter/ServiceFilter.tsx
@@ -21,13 +21,13 @@ const serviceNameFilter: FilterType = {
 export namespace ServiceFilterSelected {
   let selectedFilters: ActiveFilter[] = [];
 
-  export function setSelected(activeFilters: ActiveFilter[]) {
+  export const setSelected = (activeFilters: ActiveFilter[]) => {
     selectedFilters = activeFilters;
-  }
+  };
 
-  export function getSelected(): ActiveFilter[] {
+  export const getSelected = (): ActiveFilter[] => {
     return selectedFilters;
-  }
+  };
 }
 
 export class ServiceFilter extends React.Component<ServiceFilterProps, ServiceFilterState> {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-export function config() {
+export const config = () => {
   return {
     version: '0.1',
     backend: {
@@ -6,4 +6,4 @@ export function config() {
       password: 'password'
     }
   };
-}
+};

--- a/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -7,7 +7,7 @@ import { Nav, NavItem, TabContainer, TabContent, TabPane } from 'patternfly-reac
 import { ServiceFilterSelected } from '../../components/ServiceFilter/ServiceFilter';
 import { ActiveFilter } from '../../types/ServiceFilter';
 
-export default function ServiceDetails(routeProps: RouteComponentProps<ServiceId>) {
+const ServiceDetails = (routeProps: RouteComponentProps<ServiceId>) => {
   let updateFilter = () => {
     let activeFilter: ActiveFilter = {
       label: 'Namespace: ' + routeProps.match.params.namespace,
@@ -50,4 +50,6 @@ export default function ServiceDetails(routeProps: RouteComponentProps<ServiceId
       </TabContainer>
     </div>
   );
-}
+};
+
+export default ServiceDetails;

--- a/src/pages/ServiceDetails/__tests__/ServiceMetrics.test.tsx
+++ b/src/pages/ServiceDetails/__tests__/ServiceMetrics.test.tsx
@@ -7,7 +7,7 @@ import * as API from '../../../services/Api';
 window['SVGPathElement'] = a => a;
 let mounted: ReactWrapper<any, any> | null;
 
-function mockAPIToPromise(func: keyof typeof API, obj: any): Promise<void> {
+const mockAPIToPromise = (func: keyof typeof API, obj: any): Promise<void> => {
   return new Promise((resolve, reject) => {
     jest.spyOn(API, func).mockImplementation(() => {
       return new Promise(r => {
@@ -22,15 +22,63 @@ function mockAPIToPromise(func: keyof typeof API, obj: any): Promise<void> {
       });
     });
   });
-}
+};
 
-function mockMetrics(metrics: any): Promise<void> {
+const mockMetrics = (metrics: any): Promise<void> => {
   return mockAPIToPromise('getServiceMetrics', metrics);
-}
+};
 
-function mockGrafanaInfo(info: any): Promise<any> {
+const mockGrafanaInfo = (info: any): Promise<any> => {
   return mockAPIToPromise('getGrafanaInfo', info);
-}
+};
+
+const createMetric = (name: string) => {
+  return {
+    matrix: [
+      {
+        metric: { __name__: name },
+        values: [[1111, 5], [2222, 10]]
+      }
+    ]
+  };
+};
+
+const createHistogram = (name: string) => {
+  return {
+    average: {
+      matrix: [
+        {
+          metric: { __name__: name },
+          values: [[1111, 10], [2222, 11]]
+        }
+      ]
+    },
+    median: {
+      matrix: [
+        {
+          metric: { __name__: name },
+          values: [[1111, 20], [2222, 21]]
+        }
+      ]
+    },
+    percentile95: {
+      matrix: [
+        {
+          metric: { __name__: name },
+          values: [[1111, 30], [2222, 31]]
+        }
+      ]
+    },
+    percentile99: {
+      matrix: [
+        {
+          metric: { __name__: name },
+          values: [[1111, 40], [2222, 41]]
+        }
+      ]
+    }
+  };
+};
 
 describe('ServiceMetrics', () => {
   beforeEach(() => {
@@ -111,51 +159,3 @@ describe('ServiceMetrics', () => {
     mounted = mount(<ServiceMetrics namespace="ns" service="svc" />);
   });
 });
-
-function createMetric(name: string) {
-  return {
-    matrix: [
-      {
-        metric: { __name__: name },
-        values: [[1111, 5], [2222, 10]]
-      }
-    ]
-  };
-}
-
-function createHistogram(name: string) {
-  return {
-    average: {
-      matrix: [
-        {
-          metric: { __name__: name },
-          values: [[1111, 10], [2222, 11]]
-        }
-      ]
-    },
-    median: {
-      matrix: [
-        {
-          metric: { __name__: name },
-          values: [[1111, 20], [2222, 21]]
-        }
-      ]
-    },
-    percentile95: {
-      matrix: [
-        {
-          metric: { __name__: name },
-          values: [[1111, 30], [2222, 31]]
-        }
-      ]
-    },
-    percentile99: {
-      matrix: [
-        {
-          metric: { __name__: name },
-          values: [[1111, 40], [2222, 41]]
-        }
-      ]
-    }
-  };
-}

--- a/src/registerServiceWorker.ts
+++ b/src/registerServiceWorker.ts
@@ -17,32 +17,7 @@ const isLocalhost = Boolean(
     window.location.hostname.match(/^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/)
 );
 
-export default function register() {
-  if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
-    // The URL constructor is available in all browsers that support SW.
-    const publicUrl = new URL(process.env.PUBLIC_URL!, window.location.toString());
-    if (publicUrl.origin !== window.location.origin) {
-      // Our service worker won't work if PUBLIC_URL is on a different origin
-      // from what our page is served on. This might happen if a CDN is used to
-      // serve assets; see https://github.com/facebookincubator/create-react-app/issues/2374
-      return;
-    }
-
-    window.addEventListener('load', () => {
-      const swUrl = `${process.env.PUBLIC_URL}/service-worker.js`;
-
-      if (!isLocalhost) {
-        // Is not local host. Just register service worker
-        registerValidSW(swUrl);
-      } else {
-        // This is running on localhost. Lets check if a service worker still exists or not.
-        checkValidServiceWorker(swUrl);
-      }
-    });
-  }
-}
-
-function registerValidSW(swUrl: string) {
+const registerValidSW = (swUrl: string) => {
   navigator.serviceWorker
     .register(swUrl)
     .then(registration => {
@@ -71,9 +46,9 @@ function registerValidSW(swUrl: string) {
     .catch(error => {
       console.error('Error during service worker registration:', error);
     });
-}
+};
 
-function checkValidServiceWorker(swUrl: string) {
+const checkValidServiceWorker = (swUrl: string) => {
   // Check if the service worker can be found. If it can't reload the page.
   fetch(swUrl)
     .then(response => {
@@ -93,12 +68,39 @@ function checkValidServiceWorker(swUrl: string) {
     .catch(() => {
       console.log('No internet connection found. App is running in offline mode.');
     });
-}
+};
 
-export function unregister() {
+const register = () => {
+  if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
+    // The URL constructor is available in all browsers that support SW.
+    const publicUrl = new URL(process.env.PUBLIC_URL!, window.location.toString());
+    if (publicUrl.origin !== window.location.origin) {
+      // Our service worker won't work if PUBLIC_URL is on a different origin
+      // from what our page is served on. This might happen if a CDN is used to
+      // serve assets; see https://github.com/facebookincubator/create-react-app/issues/2374
+      return;
+    }
+
+    window.addEventListener('load', () => {
+      const swUrl = `${process.env.PUBLIC_URL}/service-worker.js`;
+
+      if (!isLocalhost) {
+        // Is not local host. Just register service worker
+        registerValidSW(swUrl);
+      } else {
+        // This is running on localhost. Lets check if a service worker still exists or not.
+        checkValidServiceWorker(swUrl);
+      }
+    });
+  }
+};
+
+export default register;
+
+export const unregister = () => {
   if ('serviceWorker' in navigator) {
     navigator.serviceWorker.ready.then(registration => {
       registration.unregister();
     });
   }
-}
+};

--- a/tslint.json
+++ b/tslint.json
@@ -61,6 +61,7 @@
             "check-open-brace",
             "check-whitespace"
         ],
+        "only-arrow-functions": true,
         "quotemark": [true, "single", "jsx-double"],
         "radix": true,
         "semicolon": [true, "always", "ignore-bound-class-methods"],


### PR DESCRIPTION

> There really should be no need for 'function'. Especially when Traditional functions don’t bind lexical scope (and Typescript does), which can lead to unexpected behavior when accessing ‘this’.
>
> https://palantir.github.io/tslint/rules/only-arrow-functions/

Replaces #35 