### PR TITLE
SWS-302 Add rateInterval to graph summary

### DIFF
--- a/src/pages/ServiceGraph/ServiceGraphPage.tsx
+++ b/src/pages/ServiceGraph/ServiceGraphPage.tsx
@@ -86,7 +86,7 @@ export default class ServiceGraphPage extends React.Component<RouteComponentProp
           <GraphFilter onFilterChange={this.filterChange} onError={this.handleError} />
         </PfHeader>
         <div style={{ position: 'relative' }}>
-          <SummaryPanel data={this.state.summaryData} />
+          <SummaryPanel data={this.state.summaryData} rateInterval={GraphFilters.getGraphInterval()} />
           <CytoscapeLayout
             namespace={GraphFilters.getGraphNamespace()}
             layout={GraphFilters.getGraphLayout()}

--- a/src/pages/ServiceGraph/SummaryPanel.tsx
+++ b/src/pages/ServiceGraph/SummaryPanel.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { SummaryPanelPropType } from '../../types/Graph';
 import SummaryPanelEdge from './SummaryPanelEdge';
 import SummaryPanelGraph from './SummaryPanelGraph';
 import SummaryPanelGroup from './SummaryPanelGroup';
@@ -8,18 +9,22 @@ type SummaryPanelState = {
   // stateless
 };
 
-type SummaryPanelProps = {
-  data: any;
-};
-
-export default class SummaryPanel extends React.Component<SummaryPanelProps, SummaryPanelState> {
+export default class SummaryPanel extends React.Component<SummaryPanelPropType, SummaryPanelState> {
   render() {
     return (
       <div>
-        {this.props.data.summaryType === 'edge' ? <SummaryPanelEdge data={this.props.data} /> : null}
-        {this.props.data.summaryType === 'graph' ? <SummaryPanelGraph data={this.props.data} /> : null}
-        {this.props.data.summaryType === 'group' ? <SummaryPanelGroup data={this.props.data} /> : null}
-        {this.props.data.summaryType === 'node' ? <SummaryPanelNode data={this.props.data} /> : null}
+        {this.props.data.summaryType === 'edge' ? (
+          <SummaryPanelEdge data={this.props.data} rateInterval={this.props.rateInterval} />
+        ) : null}
+        {this.props.data.summaryType === 'graph' ? (
+          <SummaryPanelGraph data={this.props.data} rateInterval={this.props.rateInterval} />
+        ) : null}
+        {this.props.data.summaryType === 'group' ? (
+          <SummaryPanelGroup data={this.props.data} rateInterval={this.props.rateInterval} />
+        ) : null}
+        {this.props.data.summaryType === 'node' ? (
+          <SummaryPanelNode data={this.props.data} rateInterval={this.props.rateInterval} />
+        ) : null}
       </div>
     );
   }

--- a/src/pages/ServiceGraph/SummaryPanelEdge.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelEdge.tsx
@@ -60,7 +60,8 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
   componentDidMount() {
     const options = {
       version: this.state.destVersion,
-      'byLabelsIn[]': 'source_service,source_version'
+      'byLabelsIn[]': 'source_service,source_version',
+      rateInterval: this.props.rateInterval
     };
     API.getServiceMetrics(this.state.destNamespace, this.state.destServiceName, options)
       .then(response => {

--- a/src/pages/ServiceGraph/SummaryPanelGraph.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelGraph.tsx
@@ -3,10 +3,7 @@ import * as React from 'react';
 import ServiceInfoBadge from '../../pages/ServiceDetails/ServiceInfo/ServiceInfoBadge';
 import { ErrorRatePieChart } from '../../components/SummaryPanel/ErrorRatePieChart';
 import { RpsChart } from '../../components/SummaryPanel/RpsChart';
-
-type SummaryPanelPropType = {
-  data: any;
-};
+import { SummaryPanelPropType } from '../../types/Graph';
 
 export default class SummaryPanelGraph extends React.Component<SummaryPanelPropType, {}> {
   static readonly panelStyle = {

--- a/src/pages/ServiceGraph/SummaryPanelGroup.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelGroup.tsx
@@ -6,7 +6,6 @@ import { RpsChart } from '../../components/SummaryPanel/RpsChart';
 import { SummaryPanelPropType } from '../../types/Graph';
 import * as API from '../../services/Api';
 import * as M from '../../types/Metrics';
-// import MetricsOptions from '../../types/MetricsOptions';
 
 type SummaryPanelState = {
   loading: boolean;
@@ -40,9 +39,8 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
     const namespace = this.props.data.summaryTarget.data('service').split('.')[1];
     const service = this.props.data.summaryTarget.data('service').split('.')[0];
     const options = {
-      rateInterval: '5m'
+      rateInterval: this.props.rateInterval
     };
-
     API.getServiceMetrics(namespace, service, options)
       .then(response => {
         const data: M.Metrics = response['data'];

--- a/src/pages/ServiceGraph/SummaryPanelNode.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelNode.tsx
@@ -3,10 +3,7 @@ import * as React from 'react';
 import ServiceInfoBadge from '../../pages/ServiceDetails/ServiceInfo/ServiceInfoBadge';
 import { ErrorRatePieChart } from '../../components/SummaryPanel/ErrorRatePieChart';
 import { RpsChart } from '../../components/SummaryPanel/RpsChart';
-
-type SummaryPanelPropType = {
-  data: any;
-};
+import { SummaryPanelPropType } from '../../types/Graph';
 
 export default class SummaryPanelNode extends React.Component<SummaryPanelPropType, {}> {
   static readonly panelStyle = {

--- a/src/types/Graph.ts
+++ b/src/types/Graph.ts
@@ -1,3 +1,4 @@
 export interface SummaryPanelPropType {
   data: any;
+  rateInterval: string;
 }


### PR DESCRIPTION
Add rateInterval to graph summary panels such that they reflect the same interval setting selected for the graph rendering.

