### PR TITLE
SWS-217: Display data in side panel about a selected versioned service (node) in graph

### DIFF
--- a/src/components/SummaryPanel/RpsChart.tsx
+++ b/src/components/SummaryPanel/RpsChart.tsx
@@ -4,8 +4,8 @@ import { AreaChart } from 'patternfly-react';
 
 type RpsChartTypeProp = {
   label: string;
-  dataRps: number[];
-  dataErrors: number[];
+  dataRps: number[] | [string, number][];
+  dataErrors: number[] | [string, number][];
 };
 
 export class RpsChart extends React.Component<RpsChartTypeProp, {}> {
@@ -14,26 +14,62 @@ export class RpsChart extends React.Component<RpsChartTypeProp, {}> {
   }
 
   render() {
-    let len = this.props.dataRps.length;
+    let dataRps: any[] = [],
+      dataErrors: any[] = [],
+      firstDataIdx = 0;
+    let chartData = {};
+    let axis: any = { x: { show: false }, y: { show: false } };
+
+    if (Array.isArray(this.props.dataRps[0])) {
+      dataRps = (this.props.dataRps as [string, number][])[1];
+      dataErrors = (this.props.dataErrors as [string, number][])[1];
+      firstDataIdx = 1;
+
+      chartData = {
+        x: 'x',
+        columns: (this.props.dataRps as [string, number][]).concat(this.props.dataErrors as [string, number][]),
+        type: 'area-spline'
+      };
+      axis.x = {
+        show: false,
+        type: 'timeseries',
+        tick: {
+          fit: true,
+          count: 15,
+          multiline: false,
+          format: '%H:%M:%S'
+        }
+      };
+    } else {
+      dataRps = this.props.dataRps;
+      dataErrors = this.props.dataErrors;
+
+      let rpsColumn: Array<any> = ['RPS'];
+      let errorsColumn: Array<any> = ['Errors'];
+
+      rpsColumn = rpsColumn.concat(this.props.dataRps);
+      errorsColumn = errorsColumn.concat(this.props.dataErrors);
+
+      chartData = {
+        columns: [rpsColumn, errorsColumn],
+        type: 'area-spline'
+      };
+    }
+
+    let len = dataRps.length;
     let sum = 0;
-    for (let i = 0; i < len; ++i) {
-      sum += +this.props.dataRps[i];
+    for (let i = firstDataIdx; i < len; ++i) {
+      sum += +dataRps[i];
     }
     const avgRps = len === 0 ? 0 : sum / len;
 
-    len = this.props.dataErrors.length;
+    len = dataErrors.length;
     sum = 0;
-    for (let i = 0; i < len; ++i) {
-      sum += +this.props.dataErrors[i];
+    for (let i = firstDataIdx; i < len; ++i) {
+      sum += +dataErrors[i];
     }
     const avgErr = len === 0 ? 0 : sum / len;
     const pctErr = avgRps === 0 ? 0 : avgErr / avgRps * 100;
-
-    let rpsColumn: Array<any> = ['RPS'];
-    let errorsColumn: Array<any> = ['Errors'];
-
-    rpsColumn = rpsColumn.concat(this.props.dataRps);
-    errorsColumn = errorsColumn.concat(this.props.dataErrors);
 
     return (
       <>
@@ -41,17 +77,16 @@ export class RpsChart extends React.Component<RpsChartTypeProp, {}> {
           <strong>{this.props.label}: </strong>
           {avgRps.toFixed(2)}rps / {pctErr.toFixed(2)}%Err
         </div>
-        <AreaChart
-          size={{ height: 45 }}
-          color={{ pattern: ['#0088ce', '#c00'] }}
-          legend={{ show: false }}
-          grid={{ y: { show: false } }}
-          axis={{ x: { show: false }, y: { show: false } }}
-          data={{
-            columns: [rpsColumn, errorsColumn],
-            type: 'area-spline'
-          }}
-        />
+        {this.props.dataRps.length > 0 && (
+          <AreaChart
+            size={{ height: 45 }}
+            color={{ pattern: ['#0088ce', '#c00'] }}
+            legend={{ show: false }}
+            grid={{ y: { show: false } }}
+            axis={axis}
+            data={chartData}
+          />
+        )}
       </>
     );
   }

--- a/src/pages/ServiceDetails/ServiceMetrics.tsx
+++ b/src/pages/ServiceDetails/ServiceMetrics.tsx
@@ -7,6 +7,7 @@ import Health from '../../types/Health';
 import * as API from '../../services/Api';
 import MetricsOptionsBar from '../../components/MetricsOptions/MetricsOptionsBar';
 import MetricsOptions from '../../types/MetricsOptions';
+import graphUtils from '../../utils/graphing';
 
 interface GrafanaInfo {
   url: string;
@@ -293,17 +294,18 @@ class ServiceMetrics extends React.Component<ServiceId, ServiceMetricsState> {
 
   renderMetric(id: string, metric?: M.MetricGroup) {
     if (metric) {
-      return this.renderChart(id, metric.familyName, this.toC3Columns(metric.matrix));
+      return this.renderChart(id, metric.familyName, graphUtils.toC3Columns(metric.matrix));
     }
     return <div />;
   }
 
   renderHistogram(id: string, histo?: M.Histogram) {
     if (histo) {
-      const columns = this.toC3Columns(histo.average.matrix)
-        .concat(this.toC3Columns(histo.median.matrix))
-        .concat(this.toC3Columns(histo.percentile95.matrix))
-        .concat(this.toC3Columns(histo.percentile99.matrix));
+      const columns = graphUtils
+        .toC3Columns(histo.average.matrix)
+        .concat(graphUtils.toC3Columns(histo.median.matrix))
+        .concat(graphUtils.toC3Columns(histo.percentile95.matrix))
+        .concat(graphUtils.toC3Columns(histo.percentile99.matrix));
       return this.renderChart(id, histo.familyName, columns);
     }
     return <div />;
@@ -326,20 +328,6 @@ class ServiceMetrics extends React.Component<ServiceId, ServiceMetricsState> {
       }
     };
     return <LineChart id={id} title={{ text: title }} data={data} axis={axis} point={{ show: false }} />;
-  }
-
-  toC3Columns(matrix: M.TimeSeries[]): [string, number][] {
-    return matrix
-      .map(mat => {
-        let xseries: any = ['x'];
-        return xseries.concat(mat.values.map(dp => dp[0] * 1000));
-      })
-      .concat(
-        matrix.map(mat => {
-          let yseries: any = [mat.name];
-          return yseries.concat(mat.values.map(dp => dp[1]));
-        })
-      );
   }
 }
 

--- a/src/pages/ServiceGraph/SummaryPanelNode.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelNode.tsx
@@ -1,59 +1,135 @@
 import * as React from 'react';
+import * as API from '../../services/Api';
 
+import graphUtils from '../../utils/graphing';
 import ServiceInfoBadge from '../../pages/ServiceDetails/ServiceInfo/ServiceInfoBadge';
-import { ErrorRatePieChart } from '../../components/SummaryPanel/ErrorRatePieChart';
+import { InOutRateTable } from '../../components/SummaryPanel/InOutRateTable';
 import { RpsChart } from '../../components/SummaryPanel/RpsChart';
 import { SummaryPanelPropType } from '../../types/Graph';
 
-export default class SummaryPanelNode extends React.Component<SummaryPanelPropType, {}> {
+type SummaryPanelStateType = {
+  requestCountIn: [string, number][];
+  requestCountOut: [string, number][];
+  errorCountIn: [string, number][];
+  errorCountOut: [string, number][];
+};
+
+export default class SummaryPanelNode extends React.Component<SummaryPanelPropType, SummaryPanelStateType> {
   static readonly panelStyle = {
     position: 'absolute' as 'absolute',
     width: '25em',
-    bottom: 0,
     top: 0,
     right: 0
   };
 
+  static readonly RATE = 'rate';
+  static readonly RATE3XX = 'rate3XX';
+  static readonly RATE4XX = 'rate4xx';
+  static readonly RATE5XX = 'rate5xx';
+
+  constructor(props: SummaryPanelPropType) {
+    super(props);
+    this.showRequestCountMetrics = this.showRequestCountMetrics.bind(this);
+
+    this.state = {
+      requestCountIn: [],
+      requestCountOut: [],
+      errorCountIn: [],
+      errorCountOut: []
+    };
+  }
+
+  componentDidMount() {
+    const namespace = this.props.data.summaryTarget.data('service').split('.')[1];
+    const service = this.props.data.summaryTarget.data('service').split('.')[0];
+    const version = this.props.data.summaryTarget.data('version');
+    const options = { rateInterval: '5m', version: version };
+
+    API.getServiceMetrics(namespace, service, options)
+      .then(this.showRequestCountMetrics)
+      .catch(error => {
+        console.error(error);
+      });
+  }
+
+  showRequestCountMetrics(xhrRequest: any) {
+    const metrics = xhrRequest.data.metrics;
+
+    this.setState({
+      requestCountOut: graphUtils.toC3Columns(metrics.request_count_out.matrix, 'RPS'),
+      requestCountIn: graphUtils.toC3Columns(metrics.request_count_in.matrix, 'RPS'),
+      errorCountIn: graphUtils.toC3Columns(metrics.request_error_count_in.matrix, 'Error'),
+      errorCountOut: graphUtils.toC3Columns(metrics.request_error_count_out.matrix, 'Error')
+    });
+  }
+
   render() {
-    const namespace = 'TBD';
-    const service = 'TBD';
+    const node = this.props.data.summaryTarget;
+
+    const namespace = node.data('service').split('.')[1];
+    const service = node.data('service').split('.')[0];
     const serviceHotLink = <a href={`../namespaces/${namespace}/services/${service}`}>{service}</a>;
+
+    let outgoing = { rate: 0, rate3xx: 0, rate4xx: 0, rate5xx: 0 };
+
+    // aggregate all outgoing rates
+    this.props.data.summaryTarget.edgesTo('*').forEach(c => {
+      outgoing.rate += parseFloat(c.data(SummaryPanelNode.RATE)) || 0;
+      outgoing.rate3xx += parseFloat(c.data(SummaryPanelNode.RATE3XX)) || 0;
+      outgoing.rate4xx += parseFloat(c.data(SummaryPanelNode.RATE4XX)) || 0;
+      outgoing.rate5xx += parseFloat(c.data(SummaryPanelNode.RATE5XX)) || 0;
+    });
 
     return (
       <div className="panel panel-default" style={SummaryPanelNode.panelStyle}>
-        <div className="panel-heading">Node: {serviceHotLink} (v5)</div>
+        <div className="panel-heading">Microservice: {serviceHotLink}</div>
         <div className="panel-body">
           <p>
             <strong>Labels:</strong>
             <br />
-            {this.renderLabels()}
+            <ServiceInfoBadge
+              scale={0.8}
+              style="plastic"
+              leftText="namespace"
+              rightText={namespace}
+              key={namespace}
+              color="#2d7623" // pf-green-500
+            />
+            <ServiceInfoBadge
+              scale={0.8}
+              style="plastic"
+              leftText="version"
+              rightText={this.props.data.summaryTarget.data('version')}
+              key={this.props.data.summaryTarget.data('version')}
+              color="#2d7623" // pf-green-500
+            />
           </p>
           <hr />
+          <InOutRateTable
+            title="Request Traffic (requests per second):"
+            inRate={parseFloat(node.data('rate')) || 0}
+            inRate3xx={parseFloat(node.data('rate3xx')) || 0}
+            inRate4xx={parseFloat(node.data('rate4xx')) || 0}
+            inRate5xx={parseFloat(node.data('rate5xx')) || 0}
+            outRate={outgoing.rate}
+            outRate3xx={outgoing.rate3xx}
+            outRate4xx={outgoing.rate4xx}
+            outRate5xx={outgoing.rate5xx}
+          />
           <div style={{ fontSize: '1.2em' }}>
             {this.renderIncomingRpsChart()}
             {this.renderOutgoingRpsChart()}
-            <ErrorRatePieChart percentError={10} />
           </div>
         </div>
       </div>
     );
   }
 
-  renderLabels = () => (
-    <>
-      <ServiceInfoBadge scale={0.8} style="plastic" leftText="app" rightText="bookinfo" color="green" />
-      <ServiceInfoBadge scale={0.8} style="plastic" leftText="app" rightText="product" color="green" />
-      <ServiceInfoBadge scale={0.8} style="plastic" leftText="version" rightText="v5" color="navy" />
-    </>
-  );
-
   renderIncomingRpsChart = () => {
-    return (
-      <RpsChart label="Incoming" dataRps={[350, 400, 150, 850, 50, 220]} dataErrors={[140, 100, 50, 700, 10, 110]} />
-    );
+    return <RpsChart label="Incoming" dataRps={this.state.requestCountIn} dataErrors={this.state.errorCountIn} />;
   };
 
   renderOutgoingRpsChart = () => {
-    return <RpsChart label="Outgoing" dataRps={[350, 400, 150]} dataErrors={[140, 100, 130]} />;
+    return <RpsChart label="Outgoing" dataRps={this.state.requestCountOut} dataErrors={this.state.errorCountOut} />;
   };
 }

--- a/src/utils/graphing.ts
+++ b/src/utils/graphing.ts
@@ -1,0 +1,22 @@
+import * as M from '../types/Metrics';
+
+export default {
+  toC3Columns(matrix: M.TimeSeries[], title?: string): [string, number][] {
+    if (matrix.length === 0) {
+      let ret: any = [['x'], [title]];
+      return ret;
+    }
+
+    return matrix
+      .map(mat => {
+        let xseries: any = ['x'];
+        return xseries.concat(mat.values.map(dp => dp[0] * 1000));
+      })
+      .concat(
+        matrix.map(mat => {
+          let yseries: any = [title || mat.name];
+          return yseries.concat(mat.values.map(dp => dp[1]));
+        })
+      );
+  }
+};


### PR DESCRIPTION
Using the group panel as a template. The RpsChart can now show the
timestamps of the data points if data is received with the rigth format.

Pulling out "toC3Columns" function to an utils object to reuse the code.