### PR TITLE
shouldComponentUpdate to help be able to select graph items.

### DIFF
--- a/src/pages/ServiceGraph/ServiceGraphPage.tsx
+++ b/src/pages/ServiceGraph/ServiceGraphPage.tsx
@@ -69,6 +69,13 @@ export default class ServiceGraphPage extends React.Component<RouteComponentProp
     this.setState({ summaryData: data });
   };
 
+  shouldComponentUpdate(nextProps: any, nextState: any) {
+    if (this.state.summaryData.summaryType !== nextState.summaryData.summaryType) {
+      return true;
+    }
+    return false;
+  }
+
   render() {
     let alertsDiv = <div />;
     if (this.state.alertVisible) {


### PR DESCRIPTION
this really doesn't fix the core problem, but it makes it a little better. At least now you can see the blue selection (and the selections don't disappear) if you select an item twice.

We may or may not want to merge this. As I say, it doesn't really fix the problem, but at least it allows you to select an item and see the blue outline some times.