### PR TITLE
Add Destination Policies to the Service Details page

### DIFF
--- a/src/pages/ServiceDetails/ServiceInfo.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo.tsx
@@ -1,9 +1,15 @@
 import * as React from 'react';
 import ServiceId from '../../types/ServiceId';
-import { ServiceInfoDeployments, ServiceInfoRules, ServiceInfoRoutes, ServiceInfoDescription } from './ServiceInfo/';
-import { Endpoints, Deployment, Port, Rule } from '../../types/ServiceInfo';
+import {
+  ServiceInfoDeployments,
+  ServiceInfoRouteRules,
+  ServiceInfoRoutes,
+  ServiceInfoDescription
+} from './ServiceInfo/';
+import { Endpoints, Deployment, Port, RouteRule, DestinationPolicy } from '../../types/ServiceInfo';
 import * as API from '../../services/Api';
 import { ToastNotification, ToastNotificationList, Col, Row } from 'patternfly-react';
+import ServiceInfoDestinationPolicies from './ServiceInfo/ServiceInfoDestinationPolicies';
 
 type ServiceInfoState = {
   labels?: Map<string, string>;
@@ -13,7 +19,8 @@ type ServiceInfoState = {
   ports?: Port[];
   endpoints?: Endpoints[];
   deployments?: Deployment[];
-  rules?: Rule[];
+  routeRules?: RouteRule[];
+  destinationPolicies?: DestinationPolicy[];
   dependencies?: Map<string, string[]>;
   error: boolean;
   errorMessage: string;
@@ -29,7 +36,7 @@ class ServiceInfo extends React.Component<ServiceId, ServiceInfoState> {
       ip: '',
       ports: [],
       deployments: [],
-      rules: [],
+      routeRules: [],
       dependencies: new Map(),
       error: false,
       errorMessage: ''
@@ -57,7 +64,8 @@ class ServiceInfo extends React.Component<ServiceId, ServiceInfoState> {
           endpoints: data.endpoints,
           deployments: data.deployments,
           dependencies: data.dependencies,
-          rules: data.route_rules,
+          routeRules: data.route_rules,
+          destinationPolicies: data.destination_policies,
           ip: data.ip
         });
       })
@@ -104,7 +112,8 @@ class ServiceInfo extends React.Component<ServiceId, ServiceInfoState> {
               <ServiceInfoRoutes dependencies={this.state.dependencies} />
             </Col>
             <Col xs={12} sm={6} md={4} lg={4}>
-              <ServiceInfoRules rules={this.state.rules} />
+              <ServiceInfoRouteRules routeRules={this.state.routeRules} />
+              <ServiceInfoDestinationPolicies destinationPolicies={this.state.destinationPolicies} />
             </Col>
           </Row>
         </div>

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDestinationPolicies.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDestinationPolicies.tsx
@@ -1,0 +1,122 @@
+import * as React from 'react';
+import { DestinationPolicy } from '../../../types/ServiceInfo';
+import PfInfoCard from '../../../components/Pf/PfInfoCard';
+import ServiceInfoBadge from './ServiceInfoBadge';
+
+interface ServiceInfoDestinationPoliciesProps {
+  destinationPolicies?: DestinationPolicy[];
+}
+
+class ServiceInfoDestinationPolicies extends React.Component<ServiceInfoDestinationPoliciesProps> {
+  constructor(props: ServiceInfoDestinationPoliciesProps) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <PfInfoCard
+        iconType="pf"
+        iconName="settings"
+        title="Istio Destination Policies"
+        items={(this.props.destinationPolicies || []).map((dPolicy, i) => {
+          let dPolicySource;
+          if (dPolicy.source) {
+            dPolicySource = (
+              <div>
+                <strong>Source</strong>
+                {': '}
+                {dPolicy.source.name}
+              </div>
+            );
+          }
+          let destinationLabels;
+          if (dPolicy.destination && dPolicy.destination.labels) {
+            let labels = Object.keys(dPolicy.destination.labels).map((key, n) => (
+              <li key={'_label_' + key + '_n_' + n}>
+                <ServiceInfoBadge
+                  scale={0.8}
+                  style="plastic"
+                  color="green"
+                  leftText={key}
+                  rightText={dPolicy.destination.labels ? dPolicy.destination.labels[key] : ''}
+                />
+              </li>
+            ));
+            destinationLabels = (
+              <div>
+                <strong>Destination</strong>:
+                <ul style={{ listStyleType: 'none' }}>{labels}</ul>
+              </div>
+            );
+          }
+          let loadBalancing;
+          if (dPolicy.loadbalancing) {
+            loadBalancing = (
+              <div>
+                <strong>LoadBalancing</strong>
+                {': '}
+                {dPolicy.loadbalancing.name}
+              </div>
+            );
+          }
+          let circuitBreaker;
+          if (dPolicy.circuitBreaker) {
+            circuitBreaker = (
+              <div>
+                <strong>CircuitBreaker</strong>
+                {': simpleCb'}
+                <ul style={{ listStyleType: 'none' }}>
+                  {!dPolicy.circuitBreaker.simpleCb.maxConnections ? null : (
+                    <li>maxConnections: {dPolicy.circuitBreaker.simpleCb.maxConnections}</li>
+                  )}
+                  {!dPolicy.circuitBreaker.simpleCb.httpMaxPendingRequests ? null : (
+                    <li>httpMaxPendingRequests: {dPolicy.circuitBreaker.simpleCb.httpMaxPendingRequests}</li>
+                  )}
+                  {!dPolicy.circuitBreaker.simpleCb.httpMaxRequests ? null : (
+                    <li>httpMaxRequests: {dPolicy.circuitBreaker.simpleCb.httpMaxRequests}</li>
+                  )}
+                  {!dPolicy.circuitBreaker.simpleCb.sleepWindow ? null : (
+                    <li>sleepWindow: {dPolicy.circuitBreaker.simpleCb.sleepWindow}</li>
+                  )}
+                  {!dPolicy.circuitBreaker.simpleCb.httpConsecutiveErrors ? null : (
+                    <li>httpConsecutiveErrors: {dPolicy.circuitBreaker.simpleCb.httpConsecutiveErrors}</li>
+                  )}
+                  {!dPolicy.circuitBreaker.simpleCb.httpDetectionInterval ? null : (
+                    <li>httpDetectionInterval: {dPolicy.circuitBreaker.simpleCb.httpDetectionInterval}</li>
+                  )}
+                  {!dPolicy.circuitBreaker.simpleCb.httpMaxRequestsPerConnection ? null : (
+                    <li>
+                      httpMaxRequestsPerConnection: {dPolicy.circuitBreaker.simpleCb.httpMaxRequestsPerConnection}
+                    </li>
+                  )}
+                  {!dPolicy.circuitBreaker.simpleCb.httpMaxEjectionPercent ? null : (
+                    <li>httpMaxEjectionPercent: {dPolicy.circuitBreaker.simpleCb.httpMaxEjectionPercent}</li>
+                  )}
+                  {!dPolicy.circuitBreaker.simpleCb.httpMaxRetries ? null : (
+                    <li>httpMaxRetries: {dPolicy.circuitBreaker.simpleCb.httpMaxRetries}</li>
+                  )}
+                </ul>
+              </div>
+            );
+          }
+          return (
+            <div key={'rule' + i}>
+              <div>
+                <strong>Name</strong>
+                {': '}
+                {dPolicy.name}
+              </div>
+              {dPolicySource}
+              {destinationLabels}
+              {loadBalancing}
+              {circuitBreaker}
+              <hr />
+            </div>
+          );
+        })}
+      />
+    );
+  }
+}
+
+export default ServiceInfoDestinationPolicies;

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoRouteRules.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoRouteRules.tsx
@@ -1,14 +1,14 @@
 import * as React from 'react';
 import ServiceInfoBadge from './ServiceInfoBadge';
-import { Rule } from '../../../types/ServiceInfo';
+import { RouteRule } from '../../../types/ServiceInfo';
 import PfInfoCard from '../../../components/Pf/PfInfoCard';
 
-interface ServiceInfoRulesProps {
-  rules?: Rule[];
+interface ServiceInfoRouteRulesProps {
+  routeRules?: RouteRule[];
 }
 
-class ServiceInfoRules extends React.Component<ServiceInfoRulesProps> {
-  constructor(props: ServiceInfoRulesProps) {
+class ServiceInfoRouteRules extends React.Component<ServiceInfoRouteRulesProps> {
+  constructor(props: ServiceInfoRouteRulesProps) {
     super(props);
   }
 
@@ -18,7 +18,7 @@ class ServiceInfoRules extends React.Component<ServiceInfoRulesProps> {
         iconType="pf"
         iconName="settings"
         title="Istio Route Rules"
-        items={(this.props.rules || []).map((rule, i) => (
+        items={(this.props.routeRules || []).map((rule, i) => (
           <div key={'rule' + i}>
             <div>
               <strong>Name</strong> : {rule.name}
@@ -64,4 +64,4 @@ class ServiceInfoRules extends React.Component<ServiceInfoRulesProps> {
   }
 }
 
-export default ServiceInfoRules;
+export default ServiceInfoRouteRules;

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/ServiceInfoRouteRules.test.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/ServiceInfoRouteRules.test.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import { ServiceInfoRules } from '../index';
-import { Rule } from '../../../../types/ServiceInfo';
+import { ServiceInfoRouteRules } from '../index';
+import { RouteRule } from '../../../../types/ServiceInfo';
 
-const rules: Rule[] = [
+const rules: RouteRule[] = [
   {
     name: 'reviews-default',
     destination: new Map([['name', 'reviews']]),
@@ -28,9 +28,9 @@ const rules: Rule[] = [
   }
 ];
 
-describe('#ServiceInfoRules render correctly with data', () => {
+describe('#ServiceInfoRouteRules render correctly with data', () => {
   it('should render service rules', () => {
-    const wrapper = shallow(<ServiceInfoRules rules={rules} />);
+    const wrapper = shallow(<ServiceInfoRouteRules routeRules={rules} />);
     expect(wrapper).toBeDefined();
     expect(wrapper).toMatchSnapshot();
   });

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoRouteRules.test.tsx.snap
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoRouteRules.test.tsx.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`#ServiceInfoRules render correctly with data should render service rules 1`] = `
+exports[`#ServiceInfoRouteRules render correctly with data should render service rules 1`] = `
 ShallowWrapper {
   "length": 1,
   Symbol(enzyme.__root__): [Circular],
-  Symbol(enzyme.__unrendered__): <ServiceInfoRules
-    rules={
+  Symbol(enzyme.__unrendered__): <ServiceInfoRouteRules
+    routeRules={
         Array [
             Object {
               "destination": Map {

--- a/src/pages/ServiceDetails/ServiceInfo/index.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/index.tsx
@@ -1,7 +1,15 @@
 import { default as ServiceInfoDeployments } from './ServiceInfoDeployments';
 import { default as ServiceInfoDescription } from './ServiceInfoDescription';
 import { default as ServiceInfoRoutes } from './ServiceInfoRoutes';
-import { default as ServiceInfoRules } from './ServiceInfoRules';
+import { default as ServiceInfoRouteRules } from './ServiceInfoRouteRules';
 import { default as ServiceInfoBadge } from './ServiceInfoBadge';
+import { default as ServiceInfoDestinationPolicies } from './ServiceInfoDestinationPolicies';
 
-export { ServiceInfoDeployments, ServiceInfoDescription, ServiceInfoRoutes, ServiceInfoRules, ServiceInfoBadge };
+export {
+  ServiceInfoDeployments,
+  ServiceInfoDescription,
+  ServiceInfoRoutes,
+  ServiceInfoRouteRules,
+  ServiceInfoBadge,
+  ServiceInfoDestinationPolicies
+};

--- a/src/pages/ServiceDetails/__tests__/ServiceInfo.test.tsx
+++ b/src/pages/ServiceDetails/__tests__/ServiceInfo.test.tsx
@@ -12,6 +12,7 @@ describe('#ServiceInfo render correctly with data', () => {
     expect(wrapper.find('ServiceInfoDescription').length === 1).toBeTruthy();
     expect(wrapper.find('ServiceInfoDeployments').length === 1).toBeTruthy();
     expect(wrapper.find('ServiceInfoRoutes').length === 1).toBeTruthy();
-    expect(wrapper.find('ServiceInfoRules').length === 1).toBeTruthy();
+    expect(wrapper.find('ServiceInfoRouteRules').length === 1).toBeTruthy();
+    expect(wrapper.find('ServiceInfoDestinationPolicies').length === 1).toBeTruthy();
   });
 });

--- a/src/pages/ServiceDetails/__tests__/__snapshots__/ServiceInfo.test.tsx.snap
+++ b/src/pages/ServiceDetails/__tests__/__snapshots__/ServiceInfo.test.tsx.snap
@@ -85,8 +85,11 @@ ShallowWrapper {
                               sm={6}
                               xs={12}
                     >
-                              <ServiceInfoRules
-                                        rules={Array []}
+                              <ServiceInfoRouteRules
+                                        routeRules={Array []}
+                              />
+                              <ServiceInfoDestinationPolicies
+                                        destinationPolicies={undefined}
                               />
                     </Col>
           </Row>
@@ -162,8 +165,11 @@ ShallowWrapper {
                             sm={6}
                             xs={12}
               >
-                            <ServiceInfoRules
-                                          rules={Array []}
+                            <ServiceInfoRouteRules
+                                          routeRules={Array []}
+                            />
+                            <ServiceInfoDestinationPolicies
+                                          destinationPolicies={undefined}
                             />
               </Col>
 </Row>,
@@ -279,8 +285,11 @@ ShallowWrapper {
                   sm={6}
                   xs={12}
 >
-                  <ServiceInfoRules
-                                    rules={Array []}
+                  <ServiceInfoRouteRules
+                                    routeRules={Array []}
+                  />
+                  <ServiceInfoDestinationPolicies
+                                    destinationPolicies={undefined}
                   />
 </Col>,
               ],
@@ -353,9 +362,14 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "bsClass": "col",
-                  "children": <ServiceInfoRules
-                    rules={Array []}
+                  "children": Array [
+                    <ServiceInfoRouteRules
+                      routeRules={Array []}
 />,
+                    <ServiceInfoDestinationPolicies
+                      destinationPolicies={undefined}
+/>,
+                  ],
                   "componentClass": "div",
                   "lg": 4,
                   "md": 4,
@@ -363,17 +377,30 @@ ShallowWrapper {
                   "xs": 12,
                 },
                 "ref": null,
-                "rendered": Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "class",
-                  "props": Object {
-                    "rules": Array [],
+                "rendered": Array [
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "class",
+                    "props": Object {
+                      "routeRules": Array [],
+                    },
+                    "ref": null,
+                    "rendered": null,
+                    "type": [Function],
                   },
-                  "ref": null,
-                  "rendered": null,
-                  "type": [Function],
-                },
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "class",
+                    "props": Object {
+                      "destinationPolicies": undefined,
+                    },
+                    "ref": null,
+                    "rendered": null,
+                    "type": [Function],
+                  },
+                ],
                 "type": [Function],
               },
             ],
@@ -456,8 +483,11 @@ ShallowWrapper {
                                     sm={6}
                                     xs={12}
                         >
-                                    <ServiceInfoRules
-                                                rules={Array []}
+                                    <ServiceInfoRouteRules
+                                                routeRules={Array []}
+                                    />
+                                    <ServiceInfoDestinationPolicies
+                                                destinationPolicies={undefined}
                                     />
                         </Col>
             </Row>
@@ -533,8 +563,11 @@ ShallowWrapper {
                                 sm={6}
                                 xs={12}
                 >
-                                <ServiceInfoRules
-                                                rules={Array []}
+                                <ServiceInfoRouteRules
+                                                routeRules={Array []}
+                                />
+                                <ServiceInfoDestinationPolicies
+                                                destinationPolicies={undefined}
                                 />
                 </Col>
 </Row>,
@@ -650,8 +683,11 @@ ShallowWrapper {
                     sm={6}
                     xs={12}
 >
-                    <ServiceInfoRules
-                                        rules={Array []}
+                    <ServiceInfoRouteRules
+                                        routeRules={Array []}
+                    />
+                    <ServiceInfoDestinationPolicies
+                                        destinationPolicies={undefined}
                     />
 </Col>,
                 ],
@@ -724,9 +760,14 @@ ShallowWrapper {
                   "nodeType": "class",
                   "props": Object {
                     "bsClass": "col",
-                    "children": <ServiceInfoRules
-                      rules={Array []}
+                    "children": Array [
+                      <ServiceInfoRouteRules
+                        routeRules={Array []}
 />,
+                      <ServiceInfoDestinationPolicies
+                        destinationPolicies={undefined}
+/>,
+                    ],
                     "componentClass": "div",
                     "lg": 4,
                     "md": 4,
@@ -734,17 +775,30 @@ ShallowWrapper {
                     "xs": 12,
                   },
                   "ref": null,
-                  "rendered": Object {
-                    "instance": null,
-                    "key": undefined,
-                    "nodeType": "class",
-                    "props": Object {
-                      "rules": Array [],
+                  "rendered": Array [
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "class",
+                      "props": Object {
+                        "routeRules": Array [],
+                      },
+                      "ref": null,
+                      "rendered": null,
+                      "type": [Function],
                     },
-                    "ref": null,
-                    "rendered": null,
-                    "type": [Function],
-                  },
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "class",
+                      "props": Object {
+                        "destinationPolicies": undefined,
+                      },
+                      "ref": null,
+                      "rendered": null,
+                      "type": [Function],
+                    },
+                  ],
                   "type": [Function],
                 },
               ],

--- a/src/types/ServiceInfo.ts
+++ b/src/types/ServiceInfo.ts
@@ -58,10 +58,38 @@ export interface MatchRequest {
   request?: Map<string, StringMatch>;
 }
 
-export interface Rule {
+export interface RouteRule {
   name: string;
   destination?: Map<string, string>;
   precedence?: number;
   route?: Label[];
   match?: MatchRequest;
+}
+
+export interface LoadBalancing {
+  name: string;
+}
+
+export interface CircuitBreakerPolicy {
+  maxConnections?: number;
+  httpMaxPendingRequests?: number;
+  httpMaxRequests?: number;
+  sleepWindow?: string;
+  httpConsecutiveErrors?: string;
+  httpDetectionInterval?: string;
+  httpMaxRequestsPerConnection?: number;
+  httpMaxEjectionPercent?: number;
+  httpMaxRetries?: number;
+}
+
+export interface CircuitBreaker {
+  simpleCb: CircuitBreakerPolicy;
+}
+
+export interface DestinationPolicy {
+  name: string;
+  destination: MatchSource;
+  source: MatchSource;
+  loadbalancing: LoadBalancing;
+  circuitBreaker: CircuitBreaker;
 }


### PR DESCRIPTION
This requires https://github.com/kiali/swsui/pull/140 be merged first as it has dependencies introduced there.

This is a preliminar way to present DestinationPolicies objects (load balancers, circuit breakers) attached/grouped per service, in the Service Details page.

It is just a list, not open the discussion about better UX, as further discussion about how to re-org hasn't started yet, but it makes sense to bring it into the details page as a preliminar step.

![image](https://user-images.githubusercontent.com/1662329/37699099-2372aa86-2ce6-11e8-826f-8211d333de6e.png)
