### PR TITLE
KIALI-359 Rename Istio Rules per Istio Mixer

### DIFF
--- a/src/components/Nav/Navigation.tsx
+++ b/src/components/Nav/Navigation.tsx
@@ -11,7 +11,7 @@ import ServiceGraphPage from '../../pages/ServiceGraph/ServiceGraphPage';
 import ServiceListPage from '../../pages/ServiceList/ServiceListPage';
 
 const istioRulesPath = '/rules';
-const istioRulesTitle = 'Istio Rules';
+const istioRulesTitle = 'Istio Mixer';
 const serviceGraphPath = '/service-graph/istio-system';
 const serviceGraphTitle = 'Graph';
 const servicesPath = '/services';

--- a/src/pages/IstioRuleDetails/IstioRuleDetailsPage.tsx
+++ b/src/pages/IstioRuleDetails/IstioRuleDetailsPage.tsx
@@ -19,7 +19,7 @@ const IstioRuleDetailsPage = (routeProps: RouteComponentProps<RuleId>) => {
     <div className="container-fluid container-pf-nav-pf-vertical">
       <div className="page-header">
         <h2>
-          Istio Rule{' '}
+          Istio Mixer Rule{' '}
           <Link to="/rules" onClick={updateFilter}>
             {routeProps.match.params.namespace}
           </Link>{' '}

--- a/src/pages/IstioRulesList/IstioRuleListPage.tsx
+++ b/src/pages/IstioRulesList/IstioRuleListPage.tsx
@@ -43,7 +43,7 @@ class IstioRuleListPage extends React.Component<IstioRuleListProps, IstioRuleLis
     }
     return (
       <div className="container-fluid container-pf-nav-pf-vertical">
-        <h2>Istio Rules</h2>
+        <h2>Istio Mixer Rules</h2>
         {alertsDiv}
         <IstioRuleListComponent onError={this.handleError} />
       </div>


### PR DESCRIPTION
@pilhuhn unfortunately I can't send this navigation item to the bottom with the actual patternfly-react Nav component, as I can't easily propagate a custom type there.

I will change the title first and think on refactoring this component for a following Sprint, but I didn't want to break the navigation today.