### PR TITLE
KIALI-239 Add weight attribute in ServiceInfoRouteRules

### DIFF
--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoRouteRules.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoRouteRules.tsx
@@ -30,17 +30,29 @@ class ServiceInfoRouteRules extends React.Component<ServiceInfoRouteRulesProps> 
               <strong>Route</strong>:
               <ul style={{ listStyleType: 'none' }}>
                 {(rule.route || []).map((label, u) =>
-                  Object.keys(label.labels || new Map()).map((key, n) => (
-                    <li key={'rule_' + i + '_label_' + u + '_n_' + n}>
-                      <ServiceInfoBadge
-                        scale={0.8}
-                        style="plastic"
-                        color="green"
-                        leftText={key}
-                        rightText={label.labels ? label.labels[key] : ''}
-                      />
-                    </li>
-                  ))
+                  Object.keys(label.labels || new Map()).map((key, n) => {
+                    let weight;
+                    if (label.weight) {
+                      weight = (
+                        <div>
+                          <strong>weight</strong>
+                          {': ' + label.weight + ' %'}
+                        </div>
+                      );
+                    }
+                    return (
+                      <li key={'rule_' + i + '_label_' + u + '_n_' + n}>
+                        {weight}
+                        <ServiceInfoBadge
+                          scale={0.8}
+                          style="plastic"
+                          color="green"
+                          leftText={key}
+                          rightText={label.labels ? label.labels[key] : ''}
+                        />
+                      </li>
+                    );
+                  })
                 )}
               </ul>
             </div>

--- a/src/types/ServiceInfo.ts
+++ b/src/types/ServiceInfo.ts
@@ -11,6 +11,7 @@ interface EndpointAddress {
 
 interface Label {
   labels: Map<string, string>;
+  weight?: number;
 }
 
 export interface Port {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1662329/37714896-ec80683a-2d1a-11e8-9afc-19ad5ca6b3c1.png)

When weight parameter is present in a RouteRule, it is shown in the associated label(s).
