### PR TITLE
Homologate all side panels to show timestamps for RpsCharts

### DIFF
--- a/src/components/SummaryPanel/RpsChart.tsx
+++ b/src/components/SummaryPanel/RpsChart.tsx
@@ -4,8 +4,8 @@ import { AreaChart } from 'patternfly-react';
 
 type RpsChartTypeProp = {
   label: string;
-  dataRps: number[] | [string, number][];
-  dataErrors: number[] | [string, number][];
+  dataRps: [string, number][];
+  dataErrors: [string, number][];
 };
 
 export class RpsChart extends React.Component<RpsChartTypeProp, {}> {
@@ -14,23 +14,8 @@ export class RpsChart extends React.Component<RpsChartTypeProp, {}> {
   }
 
   render() {
-    let dataRps: any[] = [],
-      dataErrors: any[] = [],
-      firstDataIdx = 0;
-    let chartData = {};
-    let axis: any = { x: { show: false }, y: { show: false } };
-
-    if (Array.isArray(this.props.dataRps[0])) {
-      dataRps = (this.props.dataRps as [string, number][])[1];
-      dataErrors = (this.props.dataErrors as [string, number][])[1];
-      firstDataIdx = 1;
-
-      chartData = {
-        x: 'x',
-        columns: (this.props.dataRps as [string, number][]).concat(this.props.dataErrors as [string, number][]),
-        type: 'area-spline'
-      };
-      axis.x = {
+    const axis: any = {
+      x: {
         show: false,
         type: 'timeseries',
         tick: {
@@ -39,33 +24,33 @@ export class RpsChart extends React.Component<RpsChartTypeProp, {}> {
           multiline: false,
           format: '%H:%M:%S'
         }
-      };
-    } else {
-      dataRps = this.props.dataRps;
-      dataErrors = this.props.dataErrors;
+      },
+      y: { show: false }
+    };
 
-      let rpsColumn: Array<any> = ['RPS'];
-      let errorsColumn: Array<any> = ['Errors'];
+    const chartData = {
+      x: 'x',
+      columns: (this.props.dataRps as [string, number][]).concat(this.props.dataErrors as [string, number][]),
+      type: 'area-spline'
+    };
 
-      rpsColumn = rpsColumn.concat(this.props.dataRps);
-      errorsColumn = errorsColumn.concat(this.props.dataErrors);
-
-      chartData = {
-        columns: [rpsColumn, errorsColumn],
-        type: 'area-spline'
-      };
+    let dataRps: any = [],
+      dataErrors: any = [];
+    if (this.props.dataRps.length > 0) {
+      dataRps = (this.props.dataRps as [string, number][])[1];
+      dataErrors = (this.props.dataErrors as [string, number][])[1];
     }
 
-    let len = dataRps.length;
+    let len: number = dataRps.length;
     let sum = 0;
-    for (let i = firstDataIdx; i < len; ++i) {
+    for (let i = 1; i < len; ++i) {
       sum += +dataRps[i];
     }
     const avgRps = len === 0 ? 0 : sum / len;
 
     len = dataErrors.length;
     sum = 0;
-    for (let i = firstDataIdx; i < len; ++i) {
+    for (let i = 1; i < len; ++i) {
       sum += +dataErrors[i];
     }
     const avgErr = len === 0 ? 0 : sum / len;
@@ -75,7 +60,7 @@ export class RpsChart extends React.Component<RpsChartTypeProp, {}> {
       <>
         <div>
           <strong>{this.props.label}: </strong>
-          {avgRps.toFixed(2)}rps / {pctErr.toFixed(2)}%Err
+          {avgRps.toFixed(2)} rps / {pctErr.toFixed(2)}% Err
         </div>
         {this.props.dataRps.length > 0 && (
           <AreaChart

--- a/src/pages/ServiceGraph/SummaryPanelGraph.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelGraph.tsx
@@ -25,7 +25,7 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
             {this.renderLabels()}
           </p>
           <hr />
-          <div style={{ fontSize: '1.2em' }}>
+          <div>
             {this.renderIncomingRpsChart()}
             {this.renderOutgoingRpsChart()}
             <ErrorRatePieChart percentError={10} />
@@ -44,12 +44,16 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
   );
 
   renderIncomingRpsChart = () => {
-    return (
-      <RpsChart label="Incoming" dataRps={[350, 400, 150, 850, 50, 220]} dataErrors={[140, 100, 50, 700, 10, 110]} />
-    );
+    const dataRps: any = [['x', 1500, 3500, 5500, 7500, 9500, 10500], ['RPS', 350, 400, 150, 850, 50, 220]];
+    const dataErrors: any = [['x', 1500, 3500, 5500, 7500, 9500, 10500], ['Error', 140, 100, 50, 700, 10, 110]];
+
+    return <RpsChart label="Incoming" dataRps={dataRps} dataErrors={dataErrors} />;
   };
 
   renderOutgoingRpsChart = () => {
-    return <RpsChart label="Outgoing" dataRps={[350, 400, 150]} dataErrors={[140, 100, 130]} />;
+    const dataRps: any = [['x', 1500, 3500, 5500], ['RPS', 350, 400, 150]];
+    const dataErrors: any = [['x', 1500, 3500, 5500], ['Error', 140, 100, 130]];
+
+    return <RpsChart label="Outgoing" dataRps={dataRps} dataErrors={dataErrors} />;
   };
 }

--- a/src/pages/ServiceGraph/SummaryPanelGroup.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelGroup.tsx
@@ -6,20 +6,20 @@ import { RpsChart } from '../../components/SummaryPanel/RpsChart';
 import { SummaryPanelPropType } from '../../types/Graph';
 import * as API from '../../services/Api';
 import * as M from '../../types/Metrics';
+import graphUtils from '../../utils/graphing';
 
 type SummaryPanelState = {
   loading: boolean;
-  requestCountIn: number[];
-  requestCountOut: number[];
-  errorCountIn: number[];
-  errorCountOut: number[];
+  requestCountIn: [string, number][];
+  requestCountOut: [string, number][];
+  errorCountIn: [string, number][];
+  errorCountOut: [string, number][];
 };
 
 export default class SummaryPanelGroup extends React.Component<SummaryPanelPropType, SummaryPanelState> {
   static readonly panelStyle = {
     position: 'absolute' as 'absolute',
     width: '25em',
-    bottom: 0,
     top: 0,
     right: 0
   };
@@ -53,10 +53,10 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
 
         this.setState({
           loading: false,
-          requestCountIn: this.pushRateDataToArray(reqCountIn.matrix),
-          requestCountOut: this.pushRateDataToArray(reqCountOut.matrix),
-          errorCountIn: this.pushRateDataToArray(errCountIn.matrix),
-          errorCountOut: this.pushRateDataToArray(errCountOut.matrix)
+          requestCountIn: graphUtils.toC3Columns(reqCountIn.matrix, 'RPS'),
+          requestCountOut: graphUtils.toC3Columns(reqCountOut.matrix, 'RPS'),
+          errorCountIn: graphUtils.toC3Columns(errCountIn.matrix, 'Error'),
+          errorCountOut: graphUtils.toC3Columns(errCountOut.matrix, 'Error')
         });
       })
       .catch(error => {
@@ -64,25 +64,6 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
         this.setState({ loading: false });
         console.error(error);
       });
-  }
-
-  // Given a timeseries, extracts the data points into an array and returns array.
-  // It is assumed the timeseries will only have at most 1 series (since we are aggregating
-  // the group data, our metrics query should only have ever returned at most 1 timeseries).
-  pushRateDataToArray(matrix: M.TimeSeries[]) {
-    let ratesArray: number[] = [];
-    if (matrix.length === 1) {
-      const ts: M.TimeSeries = matrix[0];
-      const vals: M.Datapoint[] = ts.values;
-      for (let j = 0; j < vals.length; j++) {
-        ratesArray.push(vals[j][1]);
-      }
-    } else {
-      if (matrix.length !== 0) {
-        console.error('matrix has unexpected length: ' + matrix.length);
-      }
-    }
-    return ratesArray;
   }
 
   render() {


### PR DESCRIPTION
- Change RpsChart to only allow data with timestamps.
- Fix styles of the side panel to avoid overflow of the content.