### PR TITLE
KIALI-331 graph summary for namespace

### DIFF
--- a/src/pages/ServiceGraph/ServiceGraphPage.tsx
+++ b/src/pages/ServiceGraph/ServiceGraphPage.tsx
@@ -18,6 +18,7 @@ type ServiceGraphPageProps = {
   alertVisible: boolean;
   alertDetails: string;
   summaryData: any;
+  updateTime: string;
 };
 
 export default class ServiceGraphPage extends React.Component<RouteComponentProps<NamespaceId>, ServiceGraphPageProps> {
@@ -30,7 +31,8 @@ export default class ServiceGraphPage extends React.Component<RouteComponentProp
     this.state = {
       alertVisible: false,
       alertDetails: '',
-      summaryData: { summaryType: 'graph' }
+      summaryData: { summaryType: 'graph' },
+      updateTime: new Date().toLocaleString()
     };
 
     this.filterChange = this.filterChange.bind(this);
@@ -66,7 +68,9 @@ export default class ServiceGraphPage extends React.Component<RouteComponentProp
   }
 
   handleGraphClick = (data: any) => {
-    this.setState({ summaryData: data });
+    if (data !== undefined) {
+      this.setState({ summaryData: data, updateTime: new Date().toLocaleString() });
+    }
   };
 
   render() {
@@ -86,7 +90,11 @@ export default class ServiceGraphPage extends React.Component<RouteComponentProp
           <GraphFilter onFilterChange={this.filterChange} onError={this.handleError} />
         </PfHeader>
         <div style={{ position: 'relative' }}>
-          <SummaryPanel data={this.state.summaryData} rateInterval={GraphFilters.getGraphInterval()} />
+          <SummaryPanel
+            data={this.state.summaryData}
+            namespace={GraphFilters.getGraphNamespace()}
+            rateInterval={GraphFilters.getGraphInterval()}
+          />
           <CytoscapeLayout
             namespace={GraphFilters.getGraphNamespace()}
             layout={GraphFilters.getGraphLayout()}

--- a/src/pages/ServiceGraph/SummaryPanel.tsx
+++ b/src/pages/ServiceGraph/SummaryPanel.tsx
@@ -14,16 +14,32 @@ export default class SummaryPanel extends React.Component<SummaryPanelPropType, 
     return (
       <div>
         {this.props.data.summaryType === 'edge' ? (
-          <SummaryPanelEdge data={this.props.data} rateInterval={this.props.rateInterval} />
+          <SummaryPanelEdge
+            data={this.props.data}
+            namespace={this.props.namespace}
+            rateInterval={this.props.rateInterval}
+          />
         ) : null}
         {this.props.data.summaryType === 'graph' ? (
-          <SummaryPanelGraph data={this.props.data} rateInterval={this.props.rateInterval} />
+          <SummaryPanelGraph
+            data={this.props.data}
+            namespace={this.props.namespace}
+            rateInterval={this.props.rateInterval}
+          />
         ) : null}
         {this.props.data.summaryType === 'group' ? (
-          <SummaryPanelGroup data={this.props.data} rateInterval={this.props.rateInterval} />
+          <SummaryPanelGroup
+            data={this.props.data}
+            namespace={this.props.namespace}
+            rateInterval={this.props.rateInterval}
+          />
         ) : null}
         {this.props.data.summaryType === 'node' ? (
-          <SummaryPanelNode data={this.props.data} rateInterval={this.props.rateInterval} />
+          <SummaryPanelNode
+            data={this.props.data}
+            namespace={this.props.namespace}
+            rateInterval={this.props.rateInterval}
+          />
         ) : null}
       </div>
     );

--- a/src/pages/ServiceGraph/SummaryPanelGraph.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelGraph.tsx
@@ -1,11 +1,26 @@
 import * as React from 'react';
-
 import ServiceInfoBadge from '../../pages/ServiceDetails/ServiceInfo/ServiceInfoBadge';
-import { ErrorRatePieChart } from '../../components/SummaryPanel/ErrorRatePieChart';
+import { RateTable } from '../../components/SummaryPanel/RateTable';
 import { RpsChart } from '../../components/SummaryPanel/RpsChart';
 import { SummaryPanelPropType } from '../../types/Graph';
+import graphUtils from '../../utils/graphing';
+import * as API from '../../services/Api';
+import * as M from '../../types/Metrics';
 
-export default class SummaryPanelGraph extends React.Component<SummaryPanelPropType, {}> {
+type SummaryPanelGraphState = {
+  initialized: boolean;
+  loading: boolean;
+  numNodes: number;
+  numEdges: number;
+  rate: number;
+  rate3xx: number;
+  rate4xx: number;
+  rate5xx: number;
+  reqRates: [string, number][];
+  errRates: [string, number][];
+};
+
+export default class SummaryPanelGraph extends React.Component<SummaryPanelPropType, SummaryPanelGraphState> {
   static readonly panelStyle = {
     position: 'absolute' as 'absolute',
     width: '25em',
@@ -14,46 +29,147 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
     right: 0
   };
 
+  constructor(props: SummaryPanelPropType) {
+    super(props);
+
+    this.state = {
+      initialized: false,
+      loading: true,
+      numNodes: 0,
+      numEdges: 0,
+      rate: 0,
+      rate3xx: 0,
+      rate4xx: 0,
+      rate5xx: 0,
+      reqRates: [],
+      errRates: []
+    };
+
+    const cy = this.props.data.summaryTarget;
+    if (cy !== undefined) {
+      this.initState(cy);
+    }
+  }
+
+  componentWillReceiveProps(nextProps: SummaryPanelPropType) {
+    if (this.state.initialized) {
+      return;
+    }
+    const cy = nextProps.data.summaryTarget;
+    if (cy === undefined) {
+      return;
+    }
+
+    this.initState(cy);
+
+    const options = {
+      rateInterval: this.props.rateInterval
+    };
+    API.getNamespaceMetrics(this.props.namespace, options)
+      .then(response => {
+        const data: M.Metrics = response['data'];
+        const metrics: Map<String, M.MetricGroup> = data.metrics;
+        const reqRates = this.getRates(metrics['request_count_in'], 'RPS');
+        const errRates = this.getRates(metrics['request_error_count_in'], 'Error');
+
+        this.setState({
+          loading: false,
+          reqRates: reqRates,
+          errRates: errRates
+        });
+      })
+      .catch(error => {
+        this.setState({ loading: false });
+        console.error(error);
+        // this.props.onError(error);
+      });
+  }
+
   render() {
+    // TODO, the query param is not currently supported, but this is maybe what will be used...
+    const servicesLink = <a href={`../services?namespace=${this.props.namespace}`}>{this.props.namespace}</a>;
+
     return (
       <div className="panel panel-default" style={SummaryPanelGraph.panelStyle}>
-        <div className="panel-heading">TBD</div>
-        <div className="panel-body">
-          <p>
-            <strong>Labels:</strong>
-            <br />
-            {this.renderLabels()}
-          </p>
+        <div className="panel-heading">Namespace: {servicesLink}</div>
+        <div className="panel-body" hidden={this.state.initialized}>
+          <h3>Click graph background to see summary information...</h3>
+        </div>
+        <div hidden={!this.state.initialized}>
+          <div className="panel-body">
+            <p>{this.renderLabels(this.state.numNodes.toString(), this.state.numEdges.toString())}</p>
+          </div>
           <hr />
+          <RateTable
+            title="Traffic (requests per second):"
+            rate={this.state.rate}
+            rate3xx={this.state.rate3xx}
+            rate4xx={this.state.rate4xx}
+            rate5xx={this.state.rate5xx}
+          />
           <div>
-            {this.renderIncomingRpsChart()}
-            {this.renderOutgoingRpsChart()}
-            <ErrorRatePieChart percentError={10} />
+            <hr />
+            {this.renderRpsChart()}
           </div>
         </div>
       </div>
     );
   }
 
-  renderLabels = () => (
+  private initState = cy => {
+    let numNodes = 0;
+    let numEdges = 0;
+    let rate = 0;
+    let rate3xx = 0;
+    let rate4xx = 0;
+    let rate5xx = 0;
+    let safeRate = (s: string) => {
+      return s === undefined ? 0.0 : parseFloat(s);
+    };
+
+    numNodes = cy.nodes().size();
+    numEdges = cy.edges().size();
+    cy.edges().forEach(edge => {
+      rate += +safeRate(edge.data('rate'));
+      rate3xx += +safeRate(edge.data('rate3XX'));
+      rate4xx += +safeRate(edge.data('rate4XX'));
+      rate5xx += +safeRate(edge.data('rate5XX'));
+    });
+
+    this.setState({
+      initialized: true,
+      numNodes: numNodes,
+      numEdges: numEdges,
+      rate: rate,
+      rate3xx: rate3xx,
+      rate4xx: rate4xx,
+      rate5xx: rate5xx
+    });
+  };
+
+  private renderLabels = (numNodes: string, numEdges: string) => (
     <>
-      <ServiceInfoBadge scale={0.8} style="plastic" leftText="app" rightText="bookinfo" color="green" />
-      <ServiceInfoBadge scale={0.8} style="plastic" leftText="app" rightText="product" color="green" />
-      <ServiceInfoBadge scale={0.8} style="plastic" leftText="version" rightText="v5" color="navy" />
+      <ServiceInfoBadge scale={0.8} style="plastic" leftText="services" rightText={numNodes} color="green" />
+      <ServiceInfoBadge scale={0.8} style="plastic" leftText="edges" rightText={numEdges} color="green" />
     </>
   );
 
-  renderIncomingRpsChart = () => {
-    const dataRps: any = [['x', 1500, 3500, 5500, 7500, 9500, 10500], ['RPS', 350, 400, 150, 850, 50, 220]];
-    const dataErrors: any = [['x', 1500, 3500, 5500, 7500, 9500, 10500], ['Error', 140, 100, 50, 700, 10, 110]];
+  private renderRpsChart = () => {
+    if (this.state.loading) {
+      return <strong>loading chart...</strong>;
+    }
 
-    return <RpsChart label="Incoming" dataRps={dataRps} dataErrors={dataErrors} />;
+    return <RpsChart label="Request Average" dataRps={this.state.reqRates} dataErrors={this.state.errRates} />;
   };
 
-  renderOutgoingRpsChart = () => {
-    const dataRps: any = [['x', 1500, 3500, 5500], ['RPS', 350, 400, 150]];
-    const dataErrors: any = [['x', 1500, 3500, 5500], ['Error', 140, 100, 130]];
+  private getRates = (mg: M.MetricGroup, title: string): [string, number][] => {
+    const tsa: M.TimeSeries[] = mg.matrix;
+    let series: M.TimeSeries[] = [];
 
-    return <RpsChart label="Outgoing" dataRps={dataRps} dataErrors={dataErrors} />;
+    for (let i = 0; i < tsa.length; ++i) {
+      const ts = tsa[i];
+      series.push(ts);
+    }
+    return graphUtils.toC3Columns(series, title);
   };
 }

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -35,6 +35,10 @@ export const GetNamespaces = () => {
   return newRequest('get', `/api/namespaces`, {}, {});
 };
 
+export const getNamespaceMetrics = (namespace: String, params: any) => {
+  return newRequest('get', `/api/namespaces/${namespace}/metrics`, params, {});
+};
+
 export const GetIstioRules = (namespace: String) => {
   return newRequest('get', `/api/namespaces/${namespace}/rules`, {}, {});
 };

--- a/src/types/Graph.ts
+++ b/src/types/Graph.ts
@@ -1,4 +1,5 @@
 export interface SummaryPanelPropType {
   data: any;
+  namespace: string;
   rateInterval: string;
 }


### PR DESCRIPTION
This aggregates info about all services reflected in the namespace graph
also:
- remove horizontal break in RateTable to conserve space/improve locality
- add updateTime to graph state (for future use)

NOTE: This depends on new backend support, setting to do not merge until core PR is merged.