### PR TITLE
this cleans up some things for correctness and consistency

### DIFF
--- a/src/components/SummaryPanel/InOutRateTable.tsx
+++ b/src/components/SummaryPanel/InOutRateTable.tsx
@@ -15,8 +15,8 @@ type InOutRateTablePropType = {
 
 export class InOutRateTable extends React.Component<InOutRateTablePropType, {}> {
   render() {
-    const inErrRate: number = this.props.inRate3xx + this.props.inRate4xx + this.props.inRate5xx;
-    const outErrRate: number = this.props.outRate3xx + this.props.outRate4xx + this.props.outRate5xx;
+    const inErrRate: number = this.props.inRate4xx + this.props.inRate5xx;
+    const outErrRate: number = this.props.outRate4xx + this.props.outRate5xx;
     let percentInErr: number = 0;
     let percentOutErr: number = 0;
     if (this.props.inRate !== 0) {
@@ -36,7 +36,7 @@ export class InOutRateTable extends React.Component<InOutRateTablePropType, {}> 
               <th>3xx</th>
               <th>4xx</th>
               <th>5xx</th>
-              <th>Err%</th>
+              <th>% Error</th>
             </tr>
           </thead>
           <tbody>

--- a/src/components/SummaryPanel/RateTable.tsx
+++ b/src/components/SummaryPanel/RateTable.tsx
@@ -11,7 +11,7 @@ type RateTablePropType = {
 
 export class RateTable extends React.Component<RateTablePropType, {}> {
   render() {
-    const errRate: number = this.props.rate3xx + this.props.rate4xx + this.props.rate5xx;
+    const errRate: number = this.props.rate4xx + this.props.rate5xx;
     let percentErr: number = 0;
     if (this.props.rate !== 0) {
       percentErr = errRate / this.props.rate * 100;

--- a/src/components/SummaryPanel/RpsChart.tsx
+++ b/src/components/SummaryPanel/RpsChart.tsx
@@ -65,7 +65,7 @@ export class RpsChart extends React.Component<RpsChartTypeProp, {}> {
         {this.props.dataRps.length > 0 && (
           <AreaChart
             size={{ height: 45 }}
-            color={{ pattern: ['#0088ce', '#c00'] }}
+            color={{ pattern: ['#0088ce', '#cc0000'] }} // pf-blue, pf-red-100
             legend={{ show: false }}
             grid={{ y: { show: false } }}
             axis={axis}

--- a/src/pages/ServiceGraph/SummaryPanelEdge.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelEdge.tsx
@@ -91,12 +91,12 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
     const rate5xx = this.safeRate(edge.data('rate5XX'));
     const sourceLink = (
       <a href={`../namespaces/${this.state.sourceNamespace}/services/${this.state.sourceService}`}>
-        {this.state.sourceService}
+        {this.state.sourceServiceName}
       </a>
     );
     const destLink = (
       <a href={`../namespaces/${this.state.destNamespace}/services/${this.state.destService}`}>
-        {this.state.destService}
+        {this.state.destServiceName}
       </a>
     );
 
@@ -131,9 +131,10 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
   };
 
   private renderLabels = (ns: string, ver: string) => (
+    // color="#2d7623" is pf-green-500
     <>
-      <ServiceInfoBadge scale={0.8} style="plastic" leftText="namespace" rightText={ns} color="green" />
-      <ServiceInfoBadge scale={0.8} style="plastic" leftText="version" rightText={ver} color="green" />
+      <ServiceInfoBadge scale={0.8} style="plastic" leftText="namespace" rightText={ns} color="#2d7623" />
+      <ServiceInfoBadge scale={0.8} style="plastic" leftText="version" rightText={ver} color="#2d7623" />
     </>
   );
 

--- a/src/pages/ServiceGraph/SummaryPanelGraph.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelGraph.tsx
@@ -148,9 +148,10 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
   };
 
   private renderLabels = (numNodes: string, numEdges: string) => (
+    // color="#2d7623" is pf-green-500
     <>
-      <ServiceInfoBadge scale={0.8} style="plastic" leftText="services" rightText={numNodes} color="green" />
-      <ServiceInfoBadge scale={0.8} style="plastic" leftText="edges" rightText={numEdges} color="green" />
+      <ServiceInfoBadge scale={0.8} style="plastic" leftText="services" rightText={numNodes} color="#2d7623" />
+      <ServiceInfoBadge scale={0.8} style="plastic" leftText="edges" rightText={numEdges} color="#2d7623" />
     </>
   );
 

--- a/src/pages/ServiceGraph/SummaryPanelGroup.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelGroup.tsx
@@ -76,8 +76,8 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
     const RATE4XX = 'rate4xx';
     const RATE5XX = 'rate5xx';
 
-    let incoming = { rate: 0, rate3xx: 0, rate4xx: 0, rate5xx: 0, rateErr: 0, percentErr: 0 };
-    let outgoing = { rate: 0, rate3xx: 0, rate4xx: 0, rate5xx: 0, rateErr: 0, percentErr: 0 };
+    let incoming = { rate: 0, rate3xx: 0, rate4xx: 0, rate5xx: 0 };
+    let outgoing = { rate: 0, rate3xx: 0, rate4xx: 0, rate5xx: 0 };
 
     // aggregate all incoming rates
     this.props.data.summaryTarget
@@ -89,20 +89,14 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
         }
         if (c.data(RATE3XX) !== undefined) {
           incoming.rate3xx += +c.data(RATE3XX);
-          incoming.rateErr += +c.data(RATE3XX);
         }
         if (c.data(RATE4XX) !== undefined) {
           incoming.rate4xx += +c.data(RATE4XX);
-          incoming.rateErr += +c.data(RATE4XX);
         }
         if (c.data(RATE5XX) !== undefined) {
           incoming.rate5xx += +c.data(RATE5XX);
-          incoming.rateErr += +c.data(RATE5XX);
         }
       });
-    if (incoming.rateErr !== 0) {
-      incoming.percentErr = incoming.rateErr / incoming.rate * 100.0;
-    }
     console.log('Aggregate incoming [' + namespace + '.' + service + ': ' + JSON.stringify(incoming));
 
     // aggregate all outgoing rates
@@ -115,20 +109,14 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
         }
         if (c.data(RATE3XX) !== undefined) {
           outgoing.rate3xx += +c.data(RATE3XX);
-          outgoing.rateErr += +c.data(RATE3XX);
         }
         if (c.data(RATE4XX) !== undefined) {
           outgoing.rate4xx += +c.data(RATE4XX);
-          outgoing.rateErr += +c.data(RATE4XX);
         }
         if (c.data(RATE5XX) !== undefined) {
           outgoing.rate5xx += +c.data(RATE5XX);
-          outgoing.rateErr += +c.data(RATE5XX);
         }
       });
-    if (outgoing.rateErr !== 0) {
-      outgoing.percentErr = outgoing.rateErr / outgoing.rate * 100.0;
-    }
     console.log('Aggregate outgoing [' + namespace + '.' + service + ': ' + JSON.stringify(outgoing));
 
     return (

--- a/src/pages/ServiceGraph/SummaryPanelNode.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelNode.tsx
@@ -45,7 +45,10 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
     const namespace = this.props.data.summaryTarget.data('service').split('.')[1];
     const service = this.props.data.summaryTarget.data('service').split('.')[0];
     const version = this.props.data.summaryTarget.data('version');
-    const options = { rateInterval: '5m', version: version };
+    const options = {
+      version: version,
+      rateInterval: this.props.rateInterval
+    };
 
     API.getServiceMetrics(namespace, service, options)
       .then(this.showRequestCountMetrics)


### PR DESCRIPTION
- ensure the node side-panel uses the time interval selection (it was hardcoded before)
- do not consider 3xx responses as errors
- inout and rate tables now use consistent headers
- remove unused err rate variables in group side panel
- for consistency, edge side panel uses service names like the other summary panels
- use colors as per official patternfly palette