### PR TITLE
[KIALI-242] Add link to Traces Jaeger in ServiceDetails

### DIFF
--- a/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -16,7 +16,9 @@ const ServiceDetails = (routeProps: RouteComponentProps<ServiceId>) => {
     };
     NamespaceFilterSelected.setSelected([activeFilter]);
   };
-
+  const tracesJaeger = `http://jaeger-query-istio-system.127.0.0.1.nip.io/search?service=${
+    routeProps.match.params.service
+  }`;
   return (
     <div className="container-fluid container-pf-nav-pf-vertical">
       <div className="page-header">
@@ -37,6 +39,11 @@ const ServiceDetails = (routeProps: RouteComponentProps<ServiceId>) => {
             <NavItem eventKey={2}>
               <div dangerouslySetInnerHTML={{ __html: 'Metrics' }} />
             </NavItem>
+            <li role="presentation">
+              <a href={tracesJaeger} target="_blank">
+                <div dangerouslySetInnerHTML={{ __html: 'Traces' }} />
+              </a>
+            </li>
           </Nav>
           <TabContent>
             <TabPane eventKey={1}>

--- a/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -6,57 +6,77 @@ import ServiceId from '../../types/ServiceId';
 import { Nav, NavItem, TabContainer, TabContent, TabPane } from 'patternfly-react';
 import { NamespaceFilterSelected } from '../../components/NamespaceFilter/NamespaceFilter';
 import { ActiveFilter } from '../../types/NamespaceFilter';
+import * as API from '../../services/Api';
 
-const ServiceDetails = (routeProps: RouteComponentProps<ServiceId>) => {
-  let updateFilter = () => {
+type ServiceDetailsState = {
+  jaegerUri: string;
+};
+
+class ServiceDetails extends React.Component<RouteComponentProps<ServiceId>, ServiceDetailsState> {
+  constructor(props: RouteComponentProps<ServiceId>) {
+    super(props);
+    this.state = {
+      jaegerUri: ''
+    };
+  }
+  updateFilter = () => {
     let activeFilter: ActiveFilter = {
-      label: 'Namespace: ' + routeProps.match.params.namespace,
+      label: 'Namespace: ' + this.props.match.params.namespace,
       category: 'Namespace',
-      value: routeProps.match.params.namespace.toString()
+      value: this.props.match.params.namespace.toString()
     };
     NamespaceFilterSelected.setSelected([activeFilter]);
   };
-  const tracesJaeger = `http://jaeger-query-istio-system.127.0.0.1.nip.io/search?service=${
-    routeProps.match.params.service
-  }`;
-  return (
-    <div className="container-fluid container-pf-nav-pf-vertical">
-      <div className="page-header">
-        <h2>
-          Service{' '}
-          <Link to="/services" onClick={updateFilter}>
-            {routeProps.match.params.namespace}
-          </Link>{' '}
-          / {routeProps.match.params.service}
-        </h2>
-      </div>
-      <TabContainer id="basic-tabs" defaultActiveKey={1}>
-        <div>
-          <Nav bsClass="nav nav-tabs nav-tabs-pf">
-            <NavItem eventKey={1}>
-              <div dangerouslySetInnerHTML={{ __html: 'Info' }} />
-            </NavItem>
-            <NavItem eventKey={2}>
-              <div dangerouslySetInnerHTML={{ __html: 'Metrics' }} />
-            </NavItem>
-            <li role="presentation">
-              <a href={tracesJaeger} target="_blank">
-                <div dangerouslySetInnerHTML={{ __html: 'Traces' }} />
-              </a>
-            </li>
-          </Nav>
-          <TabContent>
-            <TabPane eventKey={1}>
-              <ServiceInfo namespace={routeProps.match.params.namespace} service={routeProps.match.params.service} />
-            </TabPane>
-            <TabPane eventKey={2}>
-              <ServiceMetrics namespace={routeProps.match.params.namespace} service={routeProps.match.params.service} />
-            </TabPane>
-          </TabContent>
+  componentWillMount() {
+    API.getJaegerInfo().then(response => {
+      this.setState({
+        jaegerUri: `${response['data'].url}/search?service=${this.props.match.params.service}`
+      });
+    });
+  }
+  render() {
+    return (
+      <div className="container-fluid container-pf-nav-pf-vertical">
+        <div className="page-header">
+          <h2>
+            Service{' '}
+            <Link to="/services" onClick={this.updateFilter}>
+              {this.props.match.params.namespace}
+            </Link>{' '}
+            / {this.props.match.params.service}
+          </h2>
         </div>
-      </TabContainer>
-    </div>
-  );
-};
+        <TabContainer id="basic-tabs" defaultActiveKey={1}>
+          <div>
+            <Nav bsClass="nav nav-tabs nav-tabs-pf">
+              <NavItem eventKey={1}>
+                <div dangerouslySetInnerHTML={{ __html: 'Info' }} />
+              </NavItem>
+              <NavItem eventKey={2}>
+                <div dangerouslySetInnerHTML={{ __html: 'Metrics' }} />
+              </NavItem>
+              <li role="presentation">
+                <a href={this.state.jaegerUri} target="_blank">
+                  <div dangerouslySetInnerHTML={{ __html: 'Traces' }} />
+                </a>
+              </li>
+            </Nav>
+            <TabContent>
+              <TabPane eventKey={1}>
+                <ServiceInfo namespace={this.props.match.params.namespace} service={this.props.match.params.service} />
+              </TabPane>
+              <TabPane eventKey={2}>
+                <ServiceMetrics
+                  namespace={this.props.match.params.namespace}
+                  service={this.props.match.params.service}
+                />
+              </TabPane>
+            </TabContent>
+          </div>
+        </TabContainer>
+      </div>
+    );
+  }
+}
 
 export default ServiceDetails;

--- a/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -3,20 +3,32 @@ import { Link, RouteComponentProps } from 'react-router-dom';
 import ServiceInfo from './ServiceInfo';
 import ServiceMetrics from './ServiceMetrics';
 import ServiceId from '../../types/ServiceId';
-import { Nav, NavItem, TabContainer, TabContent, TabPane } from 'patternfly-react';
+import {
+  ToastNotification,
+  ToastNotificationList,
+  Nav,
+  NavItem,
+  TabContainer,
+  TabContent,
+  TabPane
+} from 'patternfly-react';
 import { NamespaceFilterSelected } from '../../components/NamespaceFilter/NamespaceFilter';
 import { ActiveFilter } from '../../types/NamespaceFilter';
 import * as API from '../../services/Api';
 
 type ServiceDetailsState = {
   jaegerUri: string;
+  error: boolean;
+  errorMessage: string;
 };
 
 class ServiceDetails extends React.Component<RouteComponentProps<ServiceId>, ServiceDetailsState> {
   constructor(props: RouteComponentProps<ServiceId>) {
     super(props);
     this.state = {
-      jaegerUri: ''
+      jaegerUri: '',
+      error: false,
+      errorMessage: ''
     };
   }
   updateFilter = () => {
@@ -28,15 +40,34 @@ class ServiceDetails extends React.Component<RouteComponentProps<ServiceId>, Ser
     NamespaceFilterSelected.setSelected([activeFilter]);
   };
   componentWillMount() {
-    API.getJaegerInfo().then(response => {
-      this.setState({
-        jaegerUri: `${response['data'].url}/search?service=${this.props.match.params.service}`
+    API.getJaegerInfo()
+      .then(response => {
+        this.setState({
+          jaegerUri: `${response['data'].url}/search?service=${this.props.match.params.service}`
+        });
+      })
+      .catch(error => {
+        this.setState({
+          error: true,
+          errorMessage: 'Could not connect to server'
+        });
+        console.log(error);
       });
-    });
   }
+
   render() {
     return (
       <div className="container-fluid container-pf-nav-pf-vertical">
+        {this.state.error ? (
+          <ToastNotificationList>
+            <ToastNotification type="danger">
+              <span>
+                <strong>Error </strong>
+                {this.state.errorMessage}
+              </span>
+            </ToastNotification>
+          </ToastNotificationList>
+        ) : null}
         <div className="page-header">
           <h2>
             Service{' '}

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -55,6 +55,10 @@ export const getGrafanaInfo = () => {
   return newRequest('get', `/api/grafana`, {}, {});
 };
 
+export const getJaegerInfo = () => {
+  return newRequest('get', `/api/jaeger`, {}, {});
+};
+
 export const GetGraphElements = (namespace: String, params: any) => {
   return newRequest('get', `/api/namespaces/${namespace}/graph`, params, {});
 };

--- a/src/services/__mockData__/getJaegerInfo.json
+++ b/src/services/__mockData__/getJaegerInfo.json
@@ -1,0 +1,3 @@
+{
+  "url": "http://jaeger-query-istio-system.127.0.0.1.nip.io"
+}

--- a/src/services/__mocks__/Api.ts
+++ b/src/services/__mocks__/Api.ts
@@ -41,6 +41,19 @@ export const getGrafanaInfo = () => {
   });
 };
 
+export const getJaegerInfo = () => {
+  return new Promise((resolve, reject) => {
+    fs.readFile(`./src/services/__mockData__/getJaegerInfo.json`, 'utf8', (err, data) => {
+      if (err) {
+        reject(err);
+      } else {
+        // Parse the data as JSON and put in the key entity (just like the request library does)
+        resolve(JSON.parse(data));
+      }
+    });
+  });
+};
+
 export const GetGraphElements = (namespace: string, params: any) => {
   if (GraphData.hasOwnProperty(namespace)) {
     return Promise.resolve({ data: GraphData[namespace] });

--- a/src/services/__tests__/Api.test.tsx
+++ b/src/services/__tests__/Api.test.tsx
@@ -32,6 +32,15 @@ describe('#getGrafanaInfo using Promises', () => {
   });
 });
 
+describe('#getJaegerInfo using Promises', () => {
+  it('should load the information about jaeger', () => {
+    return API.getGrafanaInfo().then(data => {
+      expect(data).toBeDefined();
+      expect(data.url).toBeDefined();
+    });
+  });
+});
+
 describe('#GetGraphElements using Promises', () => {
   it('should load service detail data', () => {
     return API.GetGraphElements('ISTIO_SYSTEM', null).then(({ data }) => {


### PR DESCRIPTION
[KIALI-242](https://issues.jboss.org/browse/KIALI-242)

Should I get the jaeger url by the backend or set it in the config file of the UI?
Actually the URI is the external one, but we can set jaeger-query, but I don't know if will keep this name for this service.

![jaeger_link](https://user-images.githubusercontent.com/3019213/37779029-aded1c7c-2deb-11e8-82c9-b6c3d797034a.gif)


The link will be like <Jaeger_Host>/search?service=<service_name> (Example : http://jaeger-query-istio-system.127.0.0.1.nip.io/search?service=jaeger-query)

cc @theute @abonas 

The link now is shoring all the traces of service, by default the query of jaeger show 20 traces of the last hour.

> http://jaeger-query-istio-system.127.0.0.1.nip.io/search?end=1521731585049000&limit=20&lookback=1h&maxDuration&minDuration&service=jaeger-query&start=1521727985049000

What kind of search we want by default when then operator go to traces?

Need https://github.com/kiali/swscore/pull/129
