### PR TITLE
KIALI-400: Set step and rateInterval dependent upon duration.

### DIFF
--- a/src/components/GraphFilter/GraphFilter.tsx
+++ b/src/components/GraphFilter/GraphFilter.tsx
@@ -12,7 +12,21 @@ import { LayoutButtonGroup } from './LayoutButtonGroup';
 import { KlayGraph } from '../CytoscapeLayout/graphs/KlayGraph';
 
 export namespace GraphFilters {
+  const graphQueryOptionsPerDuration = {
+    '60': { step: 2, rateInterval: '1m' }, // 1m - 60/2=30 buckets which is 1 datapoint per 2s
+    '600': { step: 20, rateInterval: '1m' }, // 10m - 600/20=30 buckets which is 1 datapoint per 20s
+    '1800': { step: 60, rateInterval: '1m' }, // 30m - 1800/60=30 buckets which is 1 datapoint per 1m
+    '3600': { step: 120, rateInterval: '1m' }, // 1h - 3600/120=30 buckets which is 1 datapoint per 2m
+    '14400': { step: 480, rateInterval: '1m' }, // 4h - 14400/480=30 buckets which is 1 datapoint per 8m
+    '28800': { step: 960, rateInterval: '1m' }, // 8h - 28800/960=30 buckets which is 1 datapoint per 16m
+    '86400': { step: 2880, rateInterval: '1m' }, // 1d - 86400/2880=30 buckets which is 1 datapoint per 48m
+    '604800': { step: 20160, rateInterval: '1m' }, // 7d - 604800/20160=30 buckets which is 1 datapoint per 5.6h
+    '2592000': { step: 86400, rateInterval: '1m' } // 30d - 2592000/86400=30 buckets which is 1 datapoint per 1d
+  };
+
   let graphDuration: string = '600';
+  let graphStep: number = 100;
+  let graphRateInterval: string = '1m';
   let graphLayout: any = DagreGraph.getLayout();
   let graphNamespace: string = 'istio-system';
 
@@ -32,8 +46,18 @@ export namespace GraphFilters {
     return graphNamespace;
   };
 
+  export const getGraphStep = () => {
+    return graphStep;
+  };
+
+  export const getGraphRateInterval = () => {
+    return graphRateInterval;
+  };
+
   export const setGraphDuration = (value: string) => {
     graphDuration = value;
+    graphStep = graphQueryOptionsPerDuration[value].step;
+    graphRateInterval = graphQueryOptionsPerDuration[value].rateInterval;
   };
 
   export const setGraphLayout = (value: string) => {

--- a/src/pages/ServiceGraph/ServiceGraphPage.tsx
+++ b/src/pages/ServiceGraph/ServiceGraphPage.tsx
@@ -94,6 +94,8 @@ export default class ServiceGraphPage extends React.Component<RouteComponentProp
             data={this.state.summaryData}
             namespace={GraphFilters.getGraphNamespace()}
             duration={GraphFilters.getGraphDuration()}
+            step={GraphFilters.getGraphStep()}
+            rateInterval={GraphFilters.getGraphRateInterval()}
           />
           <CytoscapeLayout
             namespace={GraphFilters.getGraphNamespace()}

--- a/src/pages/ServiceGraph/SummaryPanel.tsx
+++ b/src/pages/ServiceGraph/SummaryPanel.tsx
@@ -14,16 +14,40 @@ export default class SummaryPanel extends React.Component<SummaryPanelPropType, 
     return (
       <div>
         {this.props.data.summaryType === 'edge' ? (
-          <SummaryPanelEdge data={this.props.data} namespace={this.props.namespace} duration={this.props.duration} />
+          <SummaryPanelEdge
+            data={this.props.data}
+            namespace={this.props.namespace}
+            duration={this.props.duration}
+            step={this.props.step}
+            rateInterval={this.props.rateInterval}
+          />
         ) : null}
         {this.props.data.summaryType === 'graph' ? (
-          <SummaryPanelGraph data={this.props.data} namespace={this.props.namespace} duration={this.props.duration} />
+          <SummaryPanelGraph
+            data={this.props.data}
+            namespace={this.props.namespace}
+            duration={this.props.duration}
+            step={this.props.step}
+            rateInterval={this.props.rateInterval}
+          />
         ) : null}
         {this.props.data.summaryType === 'group' ? (
-          <SummaryPanelGroup data={this.props.data} namespace={this.props.namespace} duration={this.props.duration} />
+          <SummaryPanelGroup
+            data={this.props.data}
+            namespace={this.props.namespace}
+            duration={this.props.duration}
+            step={this.props.step}
+            rateInterval={this.props.rateInterval}
+          />
         ) : null}
         {this.props.data.summaryType === 'node' ? (
-          <SummaryPanelNode data={this.props.data} namespace={this.props.namespace} duration={this.props.duration} />
+          <SummaryPanelNode
+            data={this.props.data}
+            namespace={this.props.namespace}
+            duration={this.props.duration}
+            step={this.props.step}
+            rateInterval={this.props.rateInterval}
+          />
         ) : null}
       </div>
     );

--- a/src/pages/ServiceGraph/SummaryPanelEdge.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelEdge.tsx
@@ -103,7 +103,9 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
     const options = {
       version: destVersion,
       'byLabelsIn[]': 'source_service,source_version',
-      duration: props.duration
+      duration: props.duration,
+      step: props.step,
+      rateInterval: props.rateInterval
     };
     API.getServiceMetrics(destNamespace, destServiceName, options)
       .then(response => {

--- a/src/pages/ServiceGraph/SummaryPanelGraph.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelGraph.tsx
@@ -107,7 +107,9 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
   private updateRpsChart = (props: SummaryPanelPropType) => {
     console.log('updateRps');
     const options = {
-      duration: props.duration
+      duration: props.duration,
+      step: props.step,
+      rateInterval: props.rateInterval
     };
     console.log('updateRps get');
     API.getNamespaceMetrics(props.namespace, options)

--- a/src/pages/ServiceGraph/SummaryPanelGroup.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelGroup.tsx
@@ -137,7 +137,9 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
     const namespace = props.data.summaryTarget.data('service').split('.')[1];
     const service = props.data.summaryTarget.data('service').split('.')[0];
     const options = {
-      duration: props.duration
+      duration: props.duration,
+      step: props.step,
+      rateInterval: props.rateInterval
     };
     API.getServiceMetrics(namespace, service, options)
       .then(response => {

--- a/src/pages/ServiceGraph/SummaryPanelNode.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelNode.tsx
@@ -57,7 +57,9 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
     const version = props.data.summaryTarget.data('version');
     const options = {
       version: version,
-      duration: props.duration
+      duration: props.duration,
+      step: props.step,
+      rateInterval: props.rateInterval
     };
 
     API.getServiceMetrics(namespace, service, options)

--- a/src/types/Graph.ts
+++ b/src/types/Graph.ts
@@ -2,4 +2,6 @@ export interface SummaryPanelPropType {
   data: any;
   namespace: string;
   duration: string;
+  step: number;
+  rateInterval: string;
 }


### PR DESCRIPTION
This ensures the graph will always have 30 data points, thus making the graphs look consistent but also allowing the server-side request to execute fast even when processing as large a data set as 30 days worth.
Note the current implementation uses a consistent rate interval of 1m. Not sure if it would be more efficient to increase the interval as the data size gets larger (e.g. is it better to query with 5m rate intervals over a 7d or 30d duration?). Leaving this as-is will allow us to change intervals per duration if we need to in the future.