### PR TITLE
[KIALI-399] Select sidebar according to browser url

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,14 +1,15 @@
 import * as React from 'react';
 import './App.css';
 import Navigation from '../components/Nav/Navigation';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter, withRouter } from 'react-router-dom';
 
 class App extends React.Component {
   render() {
+    const Sidebar = withRouter(Navigation);
     return (
       <BrowserRouter basename="/console">
         <div>
-          <Navigation />
+          <Sidebar />
         </div>
       </BrowserRouter>
     );

--- a/src/components/Nav/Navigation.tsx
+++ b/src/components/Nav/Navigation.tsx
@@ -11,16 +11,24 @@ import ServiceGraphPage from '../../pages/ServiceGraph/ServiceGraphPage';
 import ServiceListPage from '../../pages/ServiceList/ServiceListPage';
 
 const istioRulesPath = '/rules';
-const istioRulesTitle = 'Istio Mixer';
+export const istioRulesTitle = 'Istio Mixer';
 const serviceGraphPath = '/service-graph/istio-system';
-const serviceGraphTitle = 'Graph';
+export const serviceGraphTitle = 'Graph';
 const servicesPath = '/services';
-const servicesTitle = 'Services';
+export const servicesTitle = 'Services';
 
 const pfLogo = require('../../img/logo-alt.svg');
 const pfBrand = require('../../assets/img/kiali-title.svg');
 
-class Navigation extends React.Component {
+type PropsType = {
+  location: any;
+};
+
+type StateType = {
+  selectedItem: string;
+};
+
+class Navigation extends React.Component<PropsType, StateType> {
   static contextTypes = {
     router: PropTypes.object
   };
@@ -28,7 +36,34 @@ class Navigation extends React.Component {
   constructor(props: any) {
     super(props);
     this.navigateTo = this.navigateTo.bind(this);
+
+    // handle initial path from the browser
+    const selected = this.parseInitialPath(props.location.pathname);
+    this.state = {
+      selectedItem: `/${selected}/`
+    };
   }
+
+  parseInitialPath = (pathname: string) => {
+    let selected = '';
+    if (pathname.startsWith('/namespaces') || pathname.startsWith('/services')) {
+      selected = servicesTitle;
+    } else if (pathname.startsWith('/service-graph')) {
+      selected = serviceGraphTitle;
+    } else if (pathname.startsWith('/rules')) {
+      selected = istioRulesTitle;
+    } else {
+      selected = serviceGraphTitle;
+    }
+    return selected;
+  };
+
+  setControlledState = event => {
+    if (event.activePath) {
+      // keep track of path as user clicks on nav bar
+      this.setState({ selectedItem: event.activePath });
+    }
+  };
 
   navigateTo(e: any) {
     if (e.title === servicesTitle) {
@@ -43,19 +78,14 @@ class Navigation extends React.Component {
   render() {
     return (
       <div>
-        <VerticalNav>
+        <VerticalNav setControlledState={this.setControlledState} activePath={this.state.selectedItem}>
           <VerticalNav.Masthead title="Swift Sunshine">
             <VerticalNav.Brand iconImg={pfLogo} titleImg={pfBrand} />
             <VerticalNav.IconBar>
               <HelpDropdown />
             </VerticalNav.IconBar>
           </VerticalNav.Masthead>
-          <VerticalNav.Item
-            title={serviceGraphTitle}
-            iconClass="fa pficon-topology"
-            onClick={this.navigateTo}
-            initialActive={true}
-          />
+          <VerticalNav.Item title={serviceGraphTitle} iconClass="fa pficon-topology" onClick={this.navigateTo} />
           <VerticalNav.Item title={servicesTitle} iconClass="fa pficon-service" onClick={this.navigateTo} />
           <VerticalNav.Item title={istioRulesTitle} iconClass="fa pficon-migration" onClick={this.navigateTo} />
         </VerticalNav>

--- a/src/components/Nav/__tests__/Navigation.test.tsx
+++ b/src/components/Nav/__tests__/Navigation.test.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+
+import Navigation, { servicesTitle, istioRulesTitle } from '../Navigation';
+import { VerticalNav } from 'patternfly-react';
+
+const _tester = (path: string, expectedMenuPath: string) => {
+  const wrapper = shallow(<Navigation location={{ pathname: path }} />);
+  const navWrapper = wrapper.find(VerticalNav);
+  expect(navWrapper.prop('activePath')).toEqual(`/${expectedMenuPath}/`);
+};
+
+describe('Navigation test', () => {
+  it('should select menu item according to browser url', () => {
+    _tester('/services', servicesTitle);
+    _tester('/rules', istioRulesTitle);
+  });
+});


### PR DESCRIPTION
- The sidebar is working as expected as you click on it
- If you bookmark and revisit a page later, while correct view is shown 'Graph' always gets selected.
- Partially addressed KIALI-399.  The hotlink is still incorrect.  For a smooth transition between views it's better to use React Router to update browser url.
https://github.com/kiali/swsui/blob/master/src/pages/ServiceGraph/SummaryPanelGraph.tsx#L78
 ```
const servicesLink = <a href={`../services?namespace=${this.props.namespace}`}>{this.props.namespace}</a>;
```